### PR TITLE
Add salting to the occurrence lookup #101

### DIFF
--- a/occurrence-persistence/src/main/java/org/gbif/occurrence/persistence/keygen/OccurrenceKeyBuilder.java
+++ b/occurrence-persistence/src/main/java/org/gbif/occurrence/persistence/keygen/OccurrenceKeyBuilder.java
@@ -9,7 +9,7 @@ import com.google.common.collect.Sets;
  */
 public class OccurrenceKeyBuilder implements KeyBuilder {
 
-  private static final String DELIM = "|";
+  public static final String DELIM = "|";
 
   @Override
   public Set<String> buildKeys(Set<String> uniqueStrings, String scope) {


### PR DESCRIPTION
I believe this adds salting to the occurrence lookup for production.

**DO NOT MERGE THIS YET**

We need to first release existing changes and then in a second isolated release stop crawling, rewrite a new lookup table using [this code](https://github.com/timrobertson100/gbif-salt-lookup) and the deploy and start up.

We need to test the dataset deletions as well as new and updating records (see the test).