### PR TITLE
#231 First step in refactoring clustering towards shared use with ALA

### DIFF
--- a/occurrence-clustering/README.md
+++ b/occurrence-clustering/README.md
@@ -12,7 +12,7 @@ The initial focus is on specimens to locate:
  2. Database duplicates across datasets (huge biases observed within datasets (e.g. gutworm datasets))
  3. Strong links between sequence records, citations and specimens
 
-This is intended to be run regularly (e.g. daily) and therefore performance is of cricital concern.
+This is intended to be run regularly (e.g. daily) and therefore performance is of critical concern.
 
 The output is bulk loaded into HBase, suitable for an API to deployed on.
 
@@ -47,7 +47,7 @@ drop table occurrence_clustering_candidates;
 drop table occurrence_relationships;
 ```
 
-Run the job (In production this configuration takes 1.7 hours with 1,6B records)
+Run the job (In production this configuration takes 1.7 hours with 1.6B records)
 ```
 nohup spark2-submit --class org.gbif.occurrence.clustering.Cluster  \
   --master yarn --num-executors 20 --executor-cores 10 \

--- a/occurrence-clustering/src/main/java/org/gbif/occurrence/clustering/OccurrenceFeatures.java
+++ b/occurrence-clustering/src/main/java/org/gbif/occurrence/clustering/OccurrenceFeatures.java
@@ -1,102 +1,31 @@
 package org.gbif.occurrence.clustering;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.scala.DefaultScalaModule;
-import org.apache.spark.sql.Row;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Set;
 import java.util.List;
-import java.util.ArrayList;
-import java.util.stream.Collectors;
 
 /**
- * A wrapper around a row giving typed access to named terms with null handling.
+ * The API to access the dimensions of an occurrence record necessary for clustering.
+ * Defined as an interface to be portable across Spark Rows, Avro objects, POJOs etc.
  */
-public class OccurrenceFeatures {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  static {
-    // required for e.g. correct empty array serializations
-    OBJECT_MAPPER.registerModule(new DefaultScalaModule());
-  }
-
-  private final Row row;
-  private final String prefix; // if field names carry prefixes e.g. t1_scientificName has t1_
-
-  // this hack is only used to correctly serialize fields containing JSON correctly
-  private final Set<String> jsonFields;
-
-  /**
-   * @param row The underlying DataSet row to expose
-   * @param prefix The prefix to strip from field names
-   * @param jsonFields Fields in Row already stored as JSON strings supplied with prefixes.
-   */
-  public OccurrenceFeatures(Row row, String prefix, String... jsonFields) {
-    this.row = row;
-    this.prefix = prefix == null ? "" : prefix;
-    this.jsonFields = jsonFields == null ? new HashSet() : new HashSet(Arrays.asList(jsonFields));
-  }
-
-  public OccurrenceFeatures(Row row, String prefix) {
-    this(row, prefix, null);
-  }
-
-  public OccurrenceFeatures(Row row) {
-    this(row, "");
-  }
-
-  <T> T get(String field) {
-    int fieldIndex = assertNotNull(row.fieldIndex(prefix + field), "Field not found in row schema: "
-      + prefix + field);
-    return row.isNullAt(fieldIndex) ? null : row.getAs(fieldIndex);
-  }
-
-  Long getLong(String field) { return get(field); }
-
-  String getString(String field) { return get(field); }
-
-  Integer getInt(String field) { return get(field); }
-
-  Double getDouble(String field) { return get(field); }
-  List<String> getStrings(String... field) {
-    List<String> vals = new ArrayList<>(field.length);
-    Arrays.stream(field).forEach(s -> vals.add(getString(s)));
-    return vals;
-  }
-
-  private static <T> T assertNotNull(T value, String message) {
-    if (value == null) throw new IllegalArgumentException(message);
-    else return value;
-  }
-
-  /**
-   * @return JSON representing all fields that match the prefix, but with the prefix removed (e.g. t1_day becomes day)
-   */
-  public String asJson() throws IOException {
-    // use the in built schema to extract all fields matching the prefix
-    String[] fieldNames = row.schema().fieldNames();
-    List<String> filteredFieldNames = Arrays.asList(fieldNames).stream()
-      .filter(s -> prefix == null || prefix.length()==0 || s.startsWith(prefix))
-      .collect(Collectors.toList());
-
-    Map<String, Object> test = new HashMap();
-    for (String field : filteredFieldNames) {
-      Object o = row.isNullAt(row.fieldIndex(field)) ? null : row.getAs(field);
-
-      if (jsonFields.contains(field)) {
-        // Hack: parse the JSON so it will not be String encoded
-        JsonNode media = OBJECT_MAPPER.readTree(String.valueOf(o));
-        test.put(field.replaceFirst(prefix, ""), media);
-      } else {
-        test.put(field.replaceFirst(prefix, ""), o);
-      }
-    }
-
-    return OBJECT_MAPPER.writeValueAsString(test);
-  }
+public interface OccurrenceFeatures {
+  String getId();
+  String getDatasetKey();
+  Integer getSpeciesKey();
+  Integer getTaxonKey();
+  String getBasisOfRecord();
+  Double getDecimalLatitude();
+  Double getDecimalLongitude();
+  Integer getYear();
+  Integer getMonth();
+  Integer getDay();
+  String getEventDate();
+  String getScientificName();
+  String getCountryCode();
+  String getTypeStatus();
+  String getOccurrenceID();
+  String getRecordedBy();
+  String getFieldNumber();
+  String getRecordNumber();
+  String getCatalogNumber();
+  String getOtherCatalogNumbers();
+  List<String> getIdentifiers();
 }

--- a/occurrence-clustering/src/main/java/org/gbif/occurrence/clustering/RelationshipAssertion.java
+++ b/occurrence-clustering/src/main/java/org/gbif/occurrence/clustering/RelationshipAssertion.java
@@ -1,19 +1,17 @@
 package org.gbif.occurrence.clustering;
 
-import java.awt.*;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
- * Models reas between occurrence records.
+ * Models relationships between occurrence records.
  *
  * This uses a String type for record identifiers allowing it to be reused beyond GBIF indexing (e.g. Atlas of Living
  * Australia)
  */
-public class RelationshipAssertion {
+public class RelationshipAssertion<T extends OccurrenceFeatures> {
 
   // Capture the reasoning why a relationship
   public enum FEATURE_ASSERTION {
@@ -36,11 +34,11 @@ public class RelationshipAssertion {
   }
 
 
-  private final OccurrenceFeatures o1;
-  private final OccurrenceFeatures o2;
-  private final Set<FEATURE_ASSERTION> justification = new TreeSet(); // reasons the assertion is being made
+  private final T o1;
+  private final T o2;
+  private final Set<FEATURE_ASSERTION> justification = new TreeSet<>(); // reasons the assertion is being made
 
-  public RelationshipAssertion(OccurrenceFeatures o1, OccurrenceFeatures o2) {
+  public RelationshipAssertion(T o1, T o2) {
     this.o1 = o1;
     this.o2 = o2;
   }
@@ -49,16 +47,16 @@ public class RelationshipAssertion {
     justification.add(reason);
   }
 
-  public OccurrenceFeatures getOcc1() {
+  public T getOcc1() {
     return o1;
   }
 
-  public OccurrenceFeatures getOcc2() {
+  public T getOcc2() {
     return o2;
   }
 
   public String getJustificationAsDelimited() {
-    return String.join(",", justification.stream().map(f -> f.name()).collect(Collectors.toList()));
+    return justification.stream().map(Enum::name).collect(Collectors.joining(","));
   }
 
   public boolean justificationContains(FEATURE_ASSERTION reason) {

--- a/occurrence-clustering/src/main/java/org/gbif/occurrence/clustering/RowOccurrenceFeatures.java
+++ b/occurrence-clustering/src/main/java/org/gbif/occurrence/clustering/RowOccurrenceFeatures.java
@@ -1,0 +1,204 @@
+package org.gbif.occurrence.clustering;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule;
+import org.apache.spark.sql.Row;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A wrapper around a row giving exposing the terms necessary for clustering.
+ * This allows terms to have a prefix, allowing a Row containing multiple records to be used (e.g. as a result of a
+ * SQL select a.*,b.* from a join b).
+ */
+public class RowOccurrenceFeatures implements OccurrenceFeatures {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  static {
+    // required for e.g. correct empty array serializations
+    OBJECT_MAPPER.registerModule(new DefaultScalaModule());
+  }
+
+  private final Row row;
+  private final String prefix; // if field names carry prefixes e.g. t1_scientificName has t1_
+
+  // this hack is only used to serialize fields containing JSON correctly
+  private final Set<String> jsonFields;
+
+  /**
+   * @param row The underlying DataSet row to expose
+   * @param prefix The prefix to strip from field names
+   * @param jsonFields Fields in Row already stored as JSON strings supplied with prefixes.
+   */
+  public RowOccurrenceFeatures(Row row, String prefix, String... jsonFields) {
+    this.row = row;
+    this.prefix = prefix == null ? "" : prefix;
+    this.jsonFields = jsonFields == null ? new HashSet<>() : new HashSet<>(Arrays.asList(jsonFields));
+  }
+
+  public RowOccurrenceFeatures(Row row, String prefix) {
+    this(row, prefix, null);
+  }
+
+  public RowOccurrenceFeatures(Row row) {
+    this(row, "");
+  }
+
+  <T> T get(String field) {
+    try {
+      int fieldIndex = row.fieldIndex(prefix + field);
+      return row.isNullAt(fieldIndex) ? null : row.getAs(fieldIndex);
+    } catch (IllegalArgumentException e) {
+      // more friendly error
+      throw new IllegalArgumentException("Field not found in row schema: " + prefix + field);
+    }
+  }
+
+  Long getLong(String field) { return get(field); }
+
+  String getString(String field) { return get(field); }
+
+  List<String> getStrings(String... field) {
+    List<String> vals = new ArrayList<>(field.length);
+    Arrays.stream(field).forEach(s -> vals.add(getString(s)));
+    return vals;
+  }
+
+  private static <T> T assertNotNull(T value, String message) {
+    if (value == null) throw new IllegalArgumentException(message);
+    else return value;
+  }
+
+  /**
+   * @return JSON representing all fields that match the prefix, but with the prefix removed (e.g. t1_day becomes day)
+   */
+  public String asJson() throws IOException {
+    // use the in built schema to extract all fields matching the prefix
+    String[] fieldNames = row.schema().fieldNames();
+    List<String> filteredFieldNames = Arrays.stream(fieldNames)
+      .filter(s -> prefix == null || prefix.length()==0 || s.startsWith(prefix))
+      .collect(Collectors.toList());
+
+    Map<String, Object> test = new HashMap<>();
+    for (String field : filteredFieldNames) {
+      Object o = row.isNullAt(row.fieldIndex(field)) ? null : row.getAs(field);
+
+      if (jsonFields.contains(field)) {
+        // Hack: parse the JSON so it will not be String encoded
+        JsonNode media = OBJECT_MAPPER.readTree(String.valueOf(o));
+        test.put(field.replaceFirst(prefix, ""), media);
+      } else {
+        test.put(field.replaceFirst(prefix, ""), o);
+      }
+    }
+
+    return OBJECT_MAPPER.writeValueAsString(test);
+  }
+
+  @Override
+  public String getId() {
+    return get("id");
+  }
+
+  @Override
+  public String getDatasetKey() {
+    return get("datasetKey");
+  }
+
+  @Override
+  public Integer getSpeciesKey() {
+    return get("speciesKey");
+  }
+
+  @Override
+  public Integer getTaxonKey() {
+    return get("taxonKey");
+  }
+
+  @Override
+  public String getBasisOfRecord() {
+    return get("basisOfRecord");
+  }
+
+  @Override
+  public Double getDecimalLatitude() {
+    return get("decimalLatitude");
+  }
+
+  @Override
+  public Double getDecimalLongitude() {
+    return get("decimalLongitude");
+  }
+
+  @Override
+  public Integer getYear() {
+    return get("year");
+  }
+
+  @Override
+  public Integer getMonth() {
+    return get("month");
+  }
+
+  @Override
+  public Integer getDay() {
+    return get("day");
+  }
+
+  @Override
+  public String getEventDate() {
+    return get("eventDate");
+  }
+
+  @Override
+  public String getScientificName() {
+    return get("scientificName");
+  }
+
+  @Override
+  public String getCountryCode() {
+    return get("countryCode");
+  }
+
+  @Override
+  public String getTypeStatus() {
+    return get("typeStatus");
+  }
+
+  @Override
+  public String getOccurrenceID() {
+    return get("occurrenceID");
+  }
+
+  @Override
+  public String getRecordedBy() {
+    return get("recordedBy");
+  }
+
+  @Override
+  public String getFieldNumber() {
+    return get("fieldNumber");
+  }
+
+  @Override
+  public String getRecordNumber() {
+    return get("recordNumber");
+  }
+
+  @Override
+  public String getCatalogNumber() {
+    return get("catalogNumber");
+  }
+
+  @Override
+  public String getOtherCatalogNumbers() {
+    return get("otherCatalogNumbers");
+  }
+
+  @Override
+  public List<String> getIdentifiers() {
+    return getStrings("occurrenceID", "fieldNumber", "recordNumber", "catalogNumber", "otherCatalogNumbers");
+  }
+}

--- a/occurrence-clustering/src/main/scala/org/gbif/occurrence/clustering/Cluster.scala
+++ b/occurrence-clustering/src/main/scala/org/gbif/occurrence/clustering/Cluster.scala
@@ -234,10 +234,10 @@ object Cluster {
     val relationships = pairs.flatMap(row => {
       val records = scala.collection.mutable.ListBuffer[Row]()
 
-      val o1 = new OccurrenceFeatures(row, "t1_", "t1_media")
-      val o2 = new OccurrenceFeatures(row, "t2_", "t2_media")
+      val o1 = new RowOccurrenceFeatures(row, "t1_", "t1_media")
+      val o2 = new RowOccurrenceFeatures(row, "t2_", "t2_media")
 
-      val relationships: Option[RelationshipAssertion] = Option(OccurrenceRelationships.generate(o1,o2))
+      val relationships: Option[RelationshipAssertion[RowOccurrenceFeatures]] = Option(OccurrenceRelationships.generate(o1,o2))
       relationships match {
         case Some(r) => {
           // store both ways

--- a/occurrence-clustering/src/test/java/org/gbif/occurrence/clustering/OccurrenceFeaturesPojo.java
+++ b/occurrence-clustering/src/test/java/org/gbif/occurrence/clustering/OccurrenceFeaturesPojo.java
@@ -1,0 +1,293 @@
+package org.gbif.occurrence.clustering;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A simple POJO implementation to aid tests.
+ */
+public class OccurrenceFeaturesPojo implements OccurrenceFeatures {
+  private String id;
+  private String datasetKey;
+  private Integer speciesKey;
+  private Integer taxonKey;
+  private String basisOfRecord;
+  private Double decimalLatitude;
+  private Double decimalLongitude;
+  private Integer year;
+  private Integer month;
+  private Integer day;
+  private String eventDate;
+  private String scientificName;
+  private String countryCode;
+  private String typeStatus;
+  private String occurrenceID;
+  private String recordedBy;
+  private String fieldNumber;
+  private String recordNumber;
+  private String catalogNumber;
+  private String otherCatalogNumbers;
+
+  private OccurrenceFeaturesPojo(String id, String datasetKey, Integer speciesKey, Integer taxonKey, String basisOfRecord, Double decimalLatitude, Double decimalLongitude, Integer year, Integer month, Integer day, String eventDate, String scientificName, String countryCode, String typeStatus, String occurrenceID, String recordedBy, String fieldNumber, String recordNumber, String catalogNumber, String otherCatalogNumbers) {
+    this.id = id;
+    this.datasetKey = datasetKey;
+    this.speciesKey = speciesKey;
+    this.taxonKey = taxonKey;
+    this.basisOfRecord = basisOfRecord;
+    this.decimalLatitude = decimalLatitude;
+    this.decimalLongitude = decimalLongitude;
+    this.year = year;
+    this.month = month;
+    this.day = day;
+    this.eventDate = eventDate;
+    this.scientificName = scientificName;
+    this.countryCode = countryCode;
+    this.typeStatus = typeStatus;
+    this.occurrenceID = occurrenceID;
+    this.recordedBy = recordedBy;
+    this.fieldNumber = fieldNumber;
+    this.recordNumber = recordNumber;
+    this.catalogNumber = catalogNumber;
+    this.otherCatalogNumbers = otherCatalogNumbers;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getDatasetKey() {
+    return datasetKey;
+  }
+
+  @Override
+  public Integer getSpeciesKey() {
+    return speciesKey;
+  }
+
+  @Override
+  public Integer getTaxonKey() {
+    return taxonKey;
+  }
+
+  @Override
+  public String getBasisOfRecord() {
+    return basisOfRecord;
+  }
+
+  @Override
+  public Double getDecimalLatitude() {
+    return decimalLatitude;
+  }
+
+  @Override
+  public Double getDecimalLongitude() {
+    return decimalLongitude;
+  }
+
+  @Override
+  public Integer getYear() {
+    return year;
+  }
+
+  @Override
+  public Integer getMonth() {
+    return month;
+  }
+
+  @Override
+  public Integer getDay() {
+    return day;
+  }
+
+  @Override
+  public String getEventDate() {
+    return eventDate;
+  }
+
+  @Override
+  public String getScientificName() {
+    return scientificName;
+  }
+
+  @Override
+  public String getCountryCode() {
+    return countryCode;
+  }
+
+  @Override
+  public String getTypeStatus() {
+    return typeStatus;
+  }
+
+  @Override
+  public String getOccurrenceID() {
+    return occurrenceID;
+  }
+
+  @Override
+  public String getRecordedBy() {
+    return recordedBy;
+  }
+
+  @Override
+  public String getFieldNumber() {
+    return fieldNumber;
+  }
+
+  @Override
+  public String getRecordNumber() {
+    return recordNumber;
+  }
+
+  @Override
+  public String getCatalogNumber() {
+    return catalogNumber;
+  }
+
+  @Override
+  public String getOtherCatalogNumbers() {
+    return otherCatalogNumbers;
+  }
+
+  @Override
+  public List<String> getIdentifiers() {
+    return Arrays.asList(
+      getOccurrenceID(), getFieldNumber(), getRecordNumber(), getCatalogNumber(), getOtherCatalogNumbers())
+      .stream().filter(Objects::nonNull).collect(Collectors.toList());
+  }
+
+  static OccurrenceFeaturesPojoBuilder newBuilder() {
+    return new OccurrenceFeaturesPojoBuilder();
+  }
+
+  static class OccurrenceFeaturesPojoBuilder {
+    private String id;
+    private String datasetKey;
+    private Integer speciesKey;
+    private Integer taxonKey;
+    private String basisOfRecord;
+    private Double decimalLatitude;
+    private Double decimalLongitude;
+    private Integer year;
+    private Integer month;
+    private Integer day;
+    private String eventDate;
+    private String scientificName;
+    private String countryCode;
+    private String typeStatus;
+    private String occurrenceID;
+    private String recordedBy;
+    private String fieldNumber;
+    private String recordNumber;
+    private String catalogNumber;
+    private String otherCatalogNumbers;
+
+    public OccurrenceFeaturesPojoBuilder setId(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setDatasetKey(String datasetKey) {
+      this.datasetKey = datasetKey;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setSpeciesKey(Integer speciesKey) {
+      this.speciesKey = speciesKey;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setTaxonKey(Integer taxonKey) {
+      this.taxonKey = taxonKey;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setBasisOfRecord(String basisOfRecord) {
+      this.basisOfRecord = basisOfRecord;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setDecimalLatitude(Double decimalLatitude) {
+      this.decimalLatitude = decimalLatitude;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setDecimalLongitude(Double decimalLongitude) {
+      this.decimalLongitude = decimalLongitude;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setYear(Integer year) {
+      this.year = year;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setMonth(Integer month) {
+      this.month = month;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setDay(Integer day) {
+      this.day = day;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setEventDate(String eventDate) {
+      this.eventDate = eventDate;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setScientificName(String scientificName) {
+      this.scientificName = scientificName;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setCountryCode(String countryCode) {
+      this.countryCode = countryCode;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setTypeStatus(String typeStatus) {
+      this.typeStatus = typeStatus;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setOccurrenceID(String occurrenceID) {
+      this.occurrenceID = occurrenceID;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setRecordedBy(String recordedBy) {
+      this.recordedBy = recordedBy;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setFieldNumber(String fieldNumber) {
+      this.fieldNumber = fieldNumber;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setRecordNumber(String recordNumber) {
+      this.recordNumber = recordNumber;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setCatalogNumber(String catalogNumber) {
+      this.catalogNumber = catalogNumber;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojoBuilder setOtherCatalogNumbers(String otherCatalogNumbers) {
+      this.otherCatalogNumbers = otherCatalogNumbers;
+      return this;
+    }
+
+    public OccurrenceFeaturesPojo build() {
+      return new OccurrenceFeaturesPojo(id, datasetKey, speciesKey, taxonKey, basisOfRecord, decimalLatitude, decimalLongitude, year, month, day, eventDate, scientificName, countryCode, typeStatus, occurrenceID, recordedBy, fieldNumber, recordNumber, catalogNumber, otherCatalogNumbers);
+    }
+  }
+}

--- a/occurrence-clustering/src/test/java/org/gbif/occurrence/clustering/OccurrenceFeaturesSparkTest.java
+++ b/occurrence-clustering/src/test/java/org/gbif/occurrence/clustering/OccurrenceFeaturesSparkTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * </pre>
  */
 
-public class OccurrenceFeaturesTest {
+public class OccurrenceFeaturesSparkTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private JavaSparkContext jsc;
@@ -56,7 +56,7 @@ public class OccurrenceFeaturesTest {
     String multimedia = first.getString(first.fieldIndex("ext_multimedia"));
     String formattedMultimedia = OBJECT_MAPPER.writeValueAsString(OBJECT_MAPPER.readTree(multimedia));
 
-    OccurrenceFeatures features = new OccurrenceFeatures(first, null, "ext_multimedia");
+    RowOccurrenceFeatures features = new RowOccurrenceFeatures(first, null, "ext_multimedia");
 
     // ensure that the resulting JSON is not escaped
     assertTrue(features.asJson().contains(formattedMultimedia));

--- a/occurrence-clustering/src/test/java/org/gbif/occurrence/clustering/OccurrenceRelationshipsTest.java
+++ b/occurrence-clustering/src/test/java/org/gbif/occurrence/clustering/OccurrenceRelationshipsTest.java
@@ -1,20 +1,8 @@
 package org.gbif.occurrence.clustering;
 
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.RowFactory;
-import org.apache.spark.sql.SQLContext;
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.gbif.occurrence.clustering.RelationshipAssertion.FEATURE_ASSERTION.APPROXIMATE_DATE;
 import static org.gbif.occurrence.clustering.RelationshipAssertion.FEATURE_ASSERTION.SAME_ACCEPTED_SPECIES;
@@ -28,84 +16,38 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for relationship assertion.
+ * Tests for relationship assertions using simple POJOs as the source.
  */
 public class OccurrenceRelationshipsTest {
-
-  // Schema mirrors the production occurrence HDFS view of GBIF
-  private static final StructType schema = new StructType(
-    new StructField[] {
-      DataTypes.createStructField("gbifId", DataTypes.LongType, true),
-      DataTypes.createStructField("datasetKey", DataTypes.StringType, true),
-      DataTypes.createStructField("basisOfRecord", DataTypes.StringType, true),
-      DataTypes.createStructField("publishingoOrgKey", DataTypes.StringType, true),
-      DataTypes.createStructField("datasetName", DataTypes.StringType, true),
-      DataTypes.createStructField("publisher", DataTypes.StringType, true),
-      DataTypes.createStructField("kingdomKey", DataTypes.IntegerType, true),
-      DataTypes.createStructField("phylumKey", DataTypes.IntegerType, true),
-      DataTypes.createStructField("classKey", DataTypes.IntegerType, true),
-      DataTypes.createStructField("orderKey", DataTypes.IntegerType, true),
-      DataTypes.createStructField("familyKey", DataTypes.IntegerType, true),
-      DataTypes.createStructField("genusKey", DataTypes.IntegerType, true),
-      DataTypes.createStructField("speciesKey", DataTypes.IntegerType, true),
-      DataTypes.createStructField("acceptedTaxonKey", DataTypes.IntegerType, true),
-      DataTypes.createStructField("taxonKey", DataTypes.IntegerType, true),
-      DataTypes.createStructField("scientificName", DataTypes.StringType, true),
-      DataTypes.createStructField("acceptedScientificName", DataTypes.StringType, true),
-      DataTypes.createStructField("kingdom", DataTypes.StringType, true),
-      DataTypes.createStructField("phylum", DataTypes.StringType, true),
-      DataTypes.createStructField("order", DataTypes.StringType, true),
-      DataTypes.createStructField("family", DataTypes.StringType, true),
-      DataTypes.createStructField("genus", DataTypes.StringType, true),
-      DataTypes.createStructField("species", DataTypes.StringType, true),
-      DataTypes.createStructField("genericName", DataTypes.StringType, true),
-      DataTypes.createStructField("specificEpithet", DataTypes.StringType, true),
-      DataTypes.createStructField("taxonRank", DataTypes.StringType, true),
-      DataTypes.createStructField("typeStatus", DataTypes.StringType, true),
-      DataTypes.createStructField("preparations", DataTypes.StringType, true),
-      DataTypes.createStructField("decimalLatitude", DataTypes.DoubleType, true),
-      DataTypes.createStructField("decimalLongitude", DataTypes.DoubleType, true),
-      DataTypes.createStructField("countryCode", DataTypes.StringType, true),
-      DataTypes.createStructField("year", DataTypes.IntegerType, true),
-      DataTypes.createStructField("month", DataTypes.IntegerType, true),
-      DataTypes.createStructField("day", DataTypes.IntegerType, true),
-      DataTypes.createStructField("eventDate", DataTypes.StringType, true),
-      DataTypes.createStructField("recordNumber", DataTypes.StringType, true),
-      DataTypes.createStructField("fieldNumber", DataTypes.StringType, true),
-      DataTypes.createStructField("occurrenceID", DataTypes.StringType, true),
-      DataTypes.createStructField("otherCatalogNumbers", DataTypes.StringType, true),
-      DataTypes.createStructField("institutionCode", DataTypes.StringType, true),
-      DataTypes.createStructField("collectionCode", DataTypes.StringType, true),
-      DataTypes.createStructField("catalogNumber", DataTypes.StringType, true),
-      DataTypes.createStructField("recordedBy", DataTypes.StringType, true),
-      DataTypes.createStructField("recordedByID", DataTypes.StringType, true),
-      DataTypes.createStructField("multi", DataTypes.StringType, true)
-    }
-  );
-
   @Test
   public void testSimpleAssertions() {
-    OccurrenceFeatures o1 = new OccurrenceFeatures(new RowBuilder()
-      .with("occurrenceID", "1")
-      .with("speciesKey", 1)
-      .with("decimalLatitude", 44.0d)
-      .with("decimalLongitude", 44.0d)
-      .with("catalogNumber", "TIM1")
-      .with("year", 1978)
-      .with("month", 12)
-      .with("day", 21)
-      .buildWithSchema());
+    OccurrenceFeatures o1 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("o1")
+        .setDatasetKey("1")
+        .setOccurrenceID("1")
+        .setSpeciesKey(1)
+        .setDecimalLatitude(44.0d)
+        .setDecimalLongitude(44.0d)
+        .setCatalogNumber("TIM1")
+        .setYear(1978)
+        .setMonth(12)
+        .setDay(21)
+        .build();
 
-    OccurrenceFeatures o2 = new OccurrenceFeatures(new RowBuilder()
-      .with("occurrenceID", "2")
-      .with("speciesKey", 1)
-      .with("decimalLatitude", 44.0d)
-      .with("decimalLongitude", 44.0d)
-      .with("catalogNumber", "//TIM1")
-      .with("year", 1978)
-      .with("month", 12)
-      .with("day", 21)
-      .buildWithSchema());
+    OccurrenceFeatures o2 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("o2")
+        .setDatasetKey("2")
+        .setOccurrenceID("2")
+        .setSpeciesKey(1)
+        .setDecimalLatitude(44.0d)
+        .setDecimalLongitude(44.0d)
+        .setCatalogNumber("TIM1")
+        .setYear(1978)
+        .setMonth(12)
+        .setDay(21)
+        .build();
 
     RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
 
@@ -113,36 +55,40 @@ public class OccurrenceRelationshipsTest {
     assertTrue(assertion.justificationContains(SAME_ACCEPTED_SPECIES));
   }
 
-  /**
-   * Real data from records 2332470913, 2571156410 which should cluster.
-   */
+  /** Real data from records 2332470913, 2571156410 which should cluster. */
   @Test
   public void testCortinarius() {
-    OccurrenceFeatures o1 = new OccurrenceFeatures(new RowBuilder()
-      .with("occurrenceID", "urn:catalog:O:F:304835")
-      .with("recordNumber", "TEB 12-16")
-      .with("speciesKey", 3348943)
-      .with("decimalLatitude", 60.3302d)
-      .with("decimalLongitude", 10.4647d)
-      .with("catalogNumber", "304835")
-      .with("year", 2016)
-      .with("month", 6)
-      .with("day", 11)
-      .with("eventDate", "2016-06-11T00:00:00")
-      .buildWithSchema());
+    OccurrenceFeatures o1 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("o1")
+        .setDatasetKey("1")
+        .setOccurrenceID("urn:catalog:O:F:304835")
+        .setRecordNumber("TEB 12-16")
+        .setSpeciesKey(3348943)
+        .setDecimalLatitude(60.3302d)
+        .setDecimalLongitude(10.4647d)
+        .setCatalogNumber("304835")
+        .setYear(2016)
+        .setMonth(6)
+        .setDay(11)
+        .setEventDate("2016-06-11T00:00:00")
+        .build();
 
-    OccurrenceFeatures o2 = new OccurrenceFeatures(new RowBuilder()
-      .with("occurrenceID", "urn:uuid:152ce614-69e1-4fbe-8f1c-3340d0a15491")
-      .with("speciesKey", 3348943)
-      .with("decimalLatitude", 60.330181d)
-      .with("decimalLongitude", 10.464743d)
-      .with("catalogNumber", "O-DFL-6644/2-D")
-      .with("recordNumber", "TEB 12-16")
-      .with("year", 2016)
-      .with("month", 6)
-      .with("day", 11)
-      .with("eventDate", "2016-06-11T00:00:00")
-      .buildWithSchema());
+    OccurrenceFeatures o2 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("o2")
+        .setDatasetKey("2")
+        .setOccurrenceID("urn:uuid:152ce614-69e1-4fbe-8f1c-3340d0a15491")
+        .setSpeciesKey(3348943)
+        .setDecimalLatitude(60.330181d)
+        .setDecimalLongitude(10.464743d)
+        .setCatalogNumber("O-DFL-6644/2-D")
+        .setRecordNumber("TEB 12-16")
+        .setYear(2016)
+        .setMonth(6)
+        .setDay(11)
+        .setEventDate("2016-06-11T00:00:00")
+        .build();
 
     RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
 
@@ -150,24 +96,31 @@ public class OccurrenceRelationshipsTest {
     assertTrue(assertion.justificationContains(SAME_ACCEPTED_SPECIES));
   }
 
-  // Test even with nonsense a Holotype of the same name must be the same specimen (or worth investigating a data issue)
+  // Test even with nonsense a Holotype of the same name must be the same specimen (or worth
+  // investigating a data issue)
   @Test
   public void testHolotype() {
-    OccurrenceFeatures o1 = new OccurrenceFeatures(new RowBuilder()
-      .with("taxonKey", 3350984)
-      .with("decimalLatitude", 10d)
-      .with("decimalLongitude", 10d)
-      .with("countryCode", "DK")
-      .with("typeStatus", "HoloType")
-      .buildWithSchema());
+    OccurrenceFeatures o1 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("o1")
+        .setDatasetKey("1")
+        .setTaxonKey(3350984)
+        .setDecimalLatitude(10d)
+        .setDecimalLongitude(10d)
+        .setCountryCode("DK")
+        .setTypeStatus("HoloType")
+        .build();
 
-    OccurrenceFeatures o2 = new OccurrenceFeatures(new RowBuilder()
-      .with("taxonKey", 3350984)
-      .with("decimalLatitude", 20d) // different
-      .with("decimalLongitude", 20d) // different
-      .with("countryCode", "NO") // different
-      .with("typeStatus", "HoloType")
-      .buildWithSchema());
+    OccurrenceFeatures o2 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("o2")
+        .setDatasetKey("2")
+        .setTaxonKey(3350984)
+        .setDecimalLatitude(20d) // different
+        .setDecimalLongitude(20d) // different
+        .setCountryCode("NO") // different
+        .setTypeStatus("HoloType")
+        .build();
 
     RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
     assertNotNull(assertion);
@@ -178,62 +131,74 @@ public class OccurrenceRelationshipsTest {
   // https://github.com/gbif/occurrence/issues/177
   @Test
   public void testDayApart() {
-    // real records where a trap set one evening and visited the next day is shared twice using different
+    // real records where a trap set one evening and visited the next day is shared twice using
+    // different
     // days
-    OccurrenceFeatures o1 = new OccurrenceFeatures(new RowBuilder()
-      .with("gbifId", 49635968)
-      .with("speciesKey", 1850114)
-      .with("decimalLatitude", 	55.737d)
-      .with("decimalLongitude", 12.538d)
-      .with("year", 2004)
-      .with("month", 8)
-      .with("day", 1) // day trap set
-      .with("countryCode", "DK")
-      .with("recordedBy", "Donald Hobern")
-      .buildWithSchema());
+    OccurrenceFeatures o1 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("49635968")
+        .setDatasetKey("1")
+        .setSpeciesKey(1850114)
+        .setDecimalLatitude(55.737d)
+        .setDecimalLongitude(12.538d)
+        .setYear(2004)
+        .setMonth(8)
+        .setDay(1) // day trap set
+        .setCountryCode("DK")
+        .setRecordedBy("Donald Hobern")
+        .build();
 
-    OccurrenceFeatures o2 = new OccurrenceFeatures(new RowBuilder()
-      .with("gbifId", 1227719129)
-      .with("speciesKey", 1850114)
-      .with("decimalLatitude", 	55.736932d) // different
-      .with("decimalLongitude", 12.538104d)
-      .with("year", 2004)
-      .with("month", 8)
-      .with("day", 2) // day collected
-      .with("countryCode", "DK")
-      .with("recordedBy", "Donald Hobern")
-      .buildWithSchema());
+    OccurrenceFeatures o2 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("1227719129")
+        .setDatasetKey("2")
+        .setSpeciesKey(1850114)
+        .setDecimalLatitude(55.736932d) // different
+        .setDecimalLongitude(12.538104d)
+        .setYear(2004)
+        .setMonth(8)
+        .setDay(2) // day collected
+        .setCountryCode("DK")
+        .setRecordedBy("Donald Hobern")
+        .build();
 
     RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
     assertNotNull(assertion);
-    assertTrue(assertion.justificationContainsAll(APPROXIMATE_DATE, WITHIN_200m, SAME_COUNTRY, SAME_RECORDER_NAME));
+    assertTrue(
+      assertion.justificationContainsAll(
+        APPROXIMATE_DATE, WITHIN_200m, SAME_COUNTRY, SAME_RECORDER_NAME));
   }
 
   // test 3 decimal place rounding example clusters
   @Test
   public void test3DP() {
     // real records of Seigler & Miller
-    OccurrenceFeatures o1 = new OccurrenceFeatures(new RowBuilder()
-      .with("gbifId", 1675790844)
-      .with("speciesKey", 3794925)
-      .with("decimalLatitude", 		21.8656d)
-      .with("decimalLongitude", -102.909d)
-      .with("year", 2007)
-      .with("month", 5)
-      .with("day", 26)
-      .with("recordedBy", "D. S. Seigler & J. T. Miller")
-      .buildWithSchema());
+    OccurrenceFeatures o1 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("1675790844")
+        .setDatasetKey("1")
+        .setSpeciesKey(3794925)
+        .setDecimalLatitude(21.8656d)
+        .setDecimalLongitude(-102.909d)
+        .setYear(2007)
+        .setMonth(5)
+        .setDay(26)
+        .setRecordedBy("D. S. Seigler & J. T. Miller")
+        .build();
 
-    OccurrenceFeatures o2 = new OccurrenceFeatures(new RowBuilder()
-      .with("gbifId", 2268858676L)
-      .with("speciesKey", 3794925)
-      .with("decimalLatitude", 		21.86558d)
-      .with("decimalLongitude", -102.90929d)
-      .with("year", 2007)
-      .with("month", 5)
-      .with("day", 26)
-      .with("recordedBy", "David S. Seigler|J.T. Miller") // we should at some point detect this match
-      .buildWithSchema());
+    OccurrenceFeatures o2 =
+      OccurrenceFeaturesPojo.newBuilder()
+        .setId("2268858676")
+        .setDatasetKey("2")
+        .setSpeciesKey(3794925)
+        .setDecimalLatitude(21.86558d)
+        .setDecimalLongitude(-102.90929d)
+        .setYear(2007)
+        .setMonth(5)
+        .setDay(26)
+        .setRecordedBy(
+          "David S. Seigler|J.T. Miller") // we should at some point detect this match
+        .build();
 
     RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
     assertNotNull(assertion);
@@ -244,78 +209,10 @@ public class OccurrenceRelationshipsTest {
   public void testNormaliseID() {
     assertEquals("ABC", OccurrenceRelationships.normalizeID(" A-/, B \\C"));
     // These are examples of collectors we could be able to organize in the future
-    assertEquals("DAVIDSSEIGLERJTMILLER", OccurrenceRelationships.normalizeID("David S. Seigler|J.T. Miller"));
-    assertEquals("DSSEIGLERJTMILLER", OccurrenceRelationships.normalizeID("D. S. Seigler & J. T. Miller"));
-  }
-
-  /**
-   * Test to simply verify that a Spark dataset row operates the same as the isolated Row tests.
-   */
-  @Test
-  public void testWithSpark() {
-    SparkConf conf = new SparkConf()
-      .setMaster("local[*]")
-      .setAppName("test")
-      .set("spark.ui.enabled", "false");
-
-    JavaSparkContext jsc = new JavaSparkContext(conf);
-    SQLContext sqlContext = new SQLContext(jsc);
-
-    try {
-      List<Row> rows = Arrays.asList(
-        new RowBuilder()
-          .with("occurrenceID", "1")
-          .with("speciesKey", 1)
-          .with("decimalLatitude", 44.0d)
-          .with("decimalLongitude", 44.0d)
-          .with("catalogNumber", "TIM1")
-          .with("year", 1978)
-          .with("month", 12)
-          .with("day", 21).buildSchemaless(),
-        new RowBuilder()
-          .with("occurrenceID", "2")
-          .with("speciesKey", 1)
-          .with("decimalLatitude", 44.0d)
-          .with("decimalLongitude", 44.0d)
-          .with("catalogNumber", "//TIM1")
-          .with("year", 1978)
-          .with("month", 12)
-          .with("day", 21)
-          .buildSchemaless());
-      final Dataset<Row> data = sqlContext.createDataFrame(rows, schema);
-      List<Row> rowData = data.collectAsList();
-
-      OccurrenceFeatures o1 = new OccurrenceFeatures(rowData.get(0));
-      OccurrenceFeatures o2 = new OccurrenceFeatures(rowData.get(1));
-
-      RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
-
-      assertNotNull(assertion);
-      assertTrue(assertion.justificationContains(SAME_ACCEPTED_SPECIES));
-    } finally {
-      jsc.stop();
-    }
-  }
-
-
-
-  /**
-   * Utility builder of rows. Rows will adhere to the schema but may be constructed with or without.
-   */
-  private static class RowBuilder {
-    private Object[] values = new Object[schema.fieldNames().length];
-
-    private RowBuilder with(String field, Object value) {
-      values[Arrays.asList(schema.fieldNames()).indexOf(field)] = value;
-      return this;
-    }
-
-    private Row buildSchemaless() {
-      return RowFactory.create(values);
-    }
-
-    private Row buildWithSchema() {
-      return new GenericRowWithSchema(values, schema);
-    }
+    assertEquals(
+      "DAVIDSSEIGLERJTMILLER",
+      OccurrenceRelationships.normalizeID("David S. Seigler|J.T. Miller"));
+    assertEquals(
+      "DSSEIGLERJTMILLER", OccurrenceRelationships.normalizeID("D. S. Seigler & J. T. Miller"));
   }
 }

--- a/occurrence-clustering/src/test/java/org/gbif/occurrence/clustering/SparkOccurrenceRelationshipsTest.java
+++ b/occurrence-clustering/src/test/java/org/gbif/occurrence/clustering/SparkOccurrenceRelationshipsTest.java
@@ -1,0 +1,312 @@
+package org.gbif.occurrence.clustering;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.gbif.occurrence.clustering.RelationshipAssertion.FEATURE_ASSERTION.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for relationship assertions when using Spark Row as the source.
+ * Further tests should be added to the OccurrenceRelationshipsTest and only spark specific tests added here.
+ */
+public class SparkOccurrenceRelationshipsTest {
+
+  // Schema mirrors the production occurrence HDFS view of GBIF
+  private static final StructType schema = new StructType(
+    new StructField[] {
+      DataTypes.createStructField("gbifId", DataTypes.LongType, true),
+      DataTypes.createStructField("datasetKey", DataTypes.StringType, true),
+      DataTypes.createStructField("basisOfRecord", DataTypes.StringType, true),
+      DataTypes.createStructField("publishingoOrgKey", DataTypes.StringType, true),
+      DataTypes.createStructField("datasetName", DataTypes.StringType, true),
+      DataTypes.createStructField("publisher", DataTypes.StringType, true),
+      DataTypes.createStructField("kingdomKey", DataTypes.IntegerType, true),
+      DataTypes.createStructField("phylumKey", DataTypes.IntegerType, true),
+      DataTypes.createStructField("classKey", DataTypes.IntegerType, true),
+      DataTypes.createStructField("orderKey", DataTypes.IntegerType, true),
+      DataTypes.createStructField("familyKey", DataTypes.IntegerType, true),
+      DataTypes.createStructField("genusKey", DataTypes.IntegerType, true),
+      DataTypes.createStructField("speciesKey", DataTypes.IntegerType, true),
+      DataTypes.createStructField("acceptedTaxonKey", DataTypes.IntegerType, true),
+      DataTypes.createStructField("taxonKey", DataTypes.IntegerType, true),
+      DataTypes.createStructField("scientificName", DataTypes.StringType, true),
+      DataTypes.createStructField("acceptedScientificName", DataTypes.StringType, true),
+      DataTypes.createStructField("kingdom", DataTypes.StringType, true),
+      DataTypes.createStructField("phylum", DataTypes.StringType, true),
+      DataTypes.createStructField("order", DataTypes.StringType, true),
+      DataTypes.createStructField("family", DataTypes.StringType, true),
+      DataTypes.createStructField("genus", DataTypes.StringType, true),
+      DataTypes.createStructField("species", DataTypes.StringType, true),
+      DataTypes.createStructField("genericName", DataTypes.StringType, true),
+      DataTypes.createStructField("specificEpithet", DataTypes.StringType, true),
+      DataTypes.createStructField("taxonRank", DataTypes.StringType, true),
+      DataTypes.createStructField("typeStatus", DataTypes.StringType, true),
+      DataTypes.createStructField("preparations", DataTypes.StringType, true),
+      DataTypes.createStructField("decimalLatitude", DataTypes.DoubleType, true),
+      DataTypes.createStructField("decimalLongitude", DataTypes.DoubleType, true),
+      DataTypes.createStructField("countryCode", DataTypes.StringType, true),
+      DataTypes.createStructField("year", DataTypes.IntegerType, true),
+      DataTypes.createStructField("month", DataTypes.IntegerType, true),
+      DataTypes.createStructField("day", DataTypes.IntegerType, true),
+      DataTypes.createStructField("eventDate", DataTypes.StringType, true),
+      DataTypes.createStructField("recordNumber", DataTypes.StringType, true),
+      DataTypes.createStructField("fieldNumber", DataTypes.StringType, true),
+      DataTypes.createStructField("occurrenceID", DataTypes.StringType, true),
+      DataTypes.createStructField("otherCatalogNumbers", DataTypes.StringType, true),
+      DataTypes.createStructField("institutionCode", DataTypes.StringType, true),
+      DataTypes.createStructField("collectionCode", DataTypes.StringType, true),
+      DataTypes.createStructField("catalogNumber", DataTypes.StringType, true),
+      DataTypes.createStructField("recordedBy", DataTypes.StringType, true),
+      DataTypes.createStructField("recordedByID", DataTypes.StringType, true),
+      DataTypes.createStructField("multi", DataTypes.StringType, true)
+    }
+  );
+
+  @Test
+  public void testSimpleAssertions() {
+    OccurrenceFeatures o1 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("occurrenceID", "1")
+      .with("speciesKey", 1)
+      .with("decimalLatitude", 44.0d)
+      .with("decimalLongitude", 44.0d)
+      .with("catalogNumber", "TIM1")
+      .with("year", 1978)
+      .with("month", 12)
+      .with("day", 21)
+      .buildWithSchema());
+
+    OccurrenceFeatures o2 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("occurrenceID", "2")
+      .with("speciesKey", 1)
+      .with("decimalLatitude", 44.0d)
+      .with("decimalLongitude", 44.0d)
+      .with("catalogNumber", "//TIM1")
+      .with("year", 1978)
+      .with("month", 12)
+      .with("day", 21)
+      .buildWithSchema());
+
+    RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
+
+    assertNotNull(assertion);
+    assertTrue(assertion.justificationContains(SAME_ACCEPTED_SPECIES));
+  }
+
+  /**
+   * Real data from records 2332470913, 2571156410 which should cluster.
+   */
+  @Test
+  public void testCortinarius() {
+    OccurrenceFeatures o1 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("occurrenceID", "urn:catalog:O:F:304835")
+      .with("recordNumber", "TEB 12-16")
+      .with("speciesKey", 3348943)
+      .with("decimalLatitude", 60.3302d)
+      .with("decimalLongitude", 10.4647d)
+      .with("catalogNumber", "304835")
+      .with("year", 2016)
+      .with("month", 6)
+      .with("day", 11)
+      .with("eventDate", "2016-06-11T00:00:00")
+      .buildWithSchema());
+
+    OccurrenceFeatures o2 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("occurrenceID", "urn:uuid:152ce614-69e1-4fbe-8f1c-3340d0a15491")
+      .with("speciesKey", 3348943)
+      .with("decimalLatitude", 60.330181d)
+      .with("decimalLongitude", 10.464743d)
+      .with("catalogNumber", "O-DFL-6644/2-D")
+      .with("recordNumber", "TEB 12-16")
+      .with("year", 2016)
+      .with("month", 6)
+      .with("day", 11)
+      .with("eventDate", "2016-06-11T00:00:00")
+      .buildWithSchema());
+
+    RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
+
+    assertNotNull(assertion);
+    assertTrue(assertion.justificationContains(SAME_ACCEPTED_SPECIES));
+  }
+
+  // Test even with nonsense a Holotype of the same name must be the same specimen (or worth investigating a data issue)
+  @Test
+  public void testHolotype() {
+    OccurrenceFeatures o1 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("taxonKey", 3350984)
+      .with("decimalLatitude", 10d)
+      .with("decimalLongitude", 10d)
+      .with("countryCode", "DK")
+      .with("typeStatus", "HoloType")
+      .buildWithSchema());
+
+    OccurrenceFeatures o2 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("taxonKey", 3350984)
+      .with("decimalLatitude", 20d) // different
+      .with("decimalLongitude", 20d) // different
+      .with("countryCode", "NO") // different
+      .with("typeStatus", "HoloType")
+      .buildWithSchema());
+
+    RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
+    assertNotNull(assertion);
+    assertTrue(assertion.justificationContains(SAME_SPECIMEN));
+  }
+
+  // Test that two records with same collector, approximate location but a day apart match.
+  // https://github.com/gbif/occurrence/issues/177
+  @Test
+  public void testDayApart() {
+    // real records where a trap set one evening and visited the next day is shared twice using different
+    // days
+    OccurrenceFeatures o1 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("gbifId", 49635968)
+      .with("speciesKey", 1850114)
+      .with("decimalLatitude", 	55.737d)
+      .with("decimalLongitude", 12.538d)
+      .with("year", 2004)
+      .with("month", 8)
+      .with("day", 1) // day trap set
+      .with("countryCode", "DK")
+      .with("recordedBy", "Donald Hobern")
+      .buildWithSchema());
+
+    OccurrenceFeatures o2 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("gbifId", 1227719129)
+      .with("speciesKey", 1850114)
+      .with("decimalLatitude", 	55.736932d) // different
+      .with("decimalLongitude", 12.538104d)
+      .with("year", 2004)
+      .with("month", 8)
+      .with("day", 2) // day collected
+      .with("countryCode", "DK")
+      .with("recordedBy", "Donald Hobern")
+      .buildWithSchema());
+
+    RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
+    assertNotNull(assertion);
+    assertTrue(assertion.justificationContainsAll(APPROXIMATE_DATE, WITHIN_200m, SAME_COUNTRY, SAME_RECORDER_NAME));
+  }
+
+  // test 3 decimal place rounding example clusters
+  @Test
+  public void test3DP() {
+    // real records of Seigler & Miller
+    OccurrenceFeatures o1 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("gbifId", 1675790844)
+      .with("speciesKey", 3794925)
+      .with("decimalLatitude", 		21.8656d)
+      .with("decimalLongitude", -102.909d)
+      .with("year", 2007)
+      .with("month", 5)
+      .with("day", 26)
+      .with("recordedBy", "D. S. Seigler & J. T. Miller")
+      .buildWithSchema());
+
+    OccurrenceFeatures o2 = new RowOccurrenceFeatures(new RowBuilder()
+      .with("gbifId", 2268858676l)
+      .with("speciesKey", 3794925)
+      .with("decimalLatitude", 		21.86558d)
+      .with("decimalLongitude", -102.90929d)
+      .with("year", 2007)
+      .with("month", 5)
+      .with("day", 26)
+      .with("recordedBy", "David S. Seigler|J.T. Miller") // we should at some point detect this match
+      .buildWithSchema());
+
+    RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
+    assertNotNull(assertion);
+    assertTrue(assertion.justificationContainsAll(SAME_DATE, WITHIN_200m, SAME_ACCEPTED_SPECIES));
+  }
+
+  @Test
+  public void testNormaliseID() {
+    assertEquals("ABC", OccurrenceRelationships.normalizeID(" A-/, B \\C"));
+    // These are examples of collectors we could be able to organize in the future
+    assertEquals("DAVIDSSEIGLERJTMILLER", OccurrenceRelationships.normalizeID("David S. Seigler|J.T. Miller"));
+    assertEquals("DSSEIGLERJTMILLER", OccurrenceRelationships.normalizeID("D. S. Seigler & J. T. Miller"));
+  }
+
+  /**
+   * Test to simply verify that a Spark dataset row operates the same as the isolated Row tests.
+   */
+  @Test
+  public void testWithSpark() {
+    SparkConf conf = new SparkConf()
+      .setMaster("local[*]")
+      .setAppName("test")
+      .set("spark.ui.enabled", "false");
+
+    JavaSparkContext jsc = new JavaSparkContext(conf);
+    SQLContext sqlContext = new SQLContext(jsc);
+
+    try {
+      List<Row> rows = Arrays.asList(
+        new RowBuilder()
+          .with("occurrenceID", "1")
+          .with("speciesKey", 1)
+          .with("decimalLatitude", 44.0d)
+          .with("decimalLongitude", 44.0d)
+          .with("catalogNumber", "TIM1")
+          .with("year", 1978)
+          .with("month", 12)
+          .with("day", 21).buildSchemaless(),
+        new RowBuilder()
+          .with("occurrenceID", "2")
+          .with("speciesKey", 1)
+          .with("decimalLatitude", 44.0d)
+          .with("decimalLongitude", 44.0d)
+          .with("catalogNumber", "//TIM1")
+          .with("year", 1978)
+          .with("month", 12)
+          .with("day", 21)
+          .buildSchemaless());
+      final Dataset<Row> data = sqlContext.createDataFrame(rows, schema);
+      List<Row> rowData = data.collectAsList();
+
+      OccurrenceFeatures o1 = new RowOccurrenceFeatures(rowData.get(0));
+      OccurrenceFeatures o2 = new RowOccurrenceFeatures(rowData.get(1));
+
+      RelationshipAssertion assertion = OccurrenceRelationships.generate(o1, o2);
+
+      assertNotNull(assertion);
+      assertTrue(assertion.justificationContains(SAME_ACCEPTED_SPECIES));
+    } finally {
+      jsc.stop();
+    }
+  }
+
+  /**
+   * Utility builder of rows. Rows will adhere to the schema but may be constructed with or without.
+   */
+  private static class RowBuilder {
+    private Object[] values = new Object[schema.fieldNames().length];
+
+    private RowBuilder with(String field, Object value) {
+      values[Arrays.asList(schema.fieldNames()).indexOf(field)] = value;
+      return this;
+    }
+
+    private Row buildSchemaless() {
+      return RowFactory.create(values);
+    }
+
+    private Row buildWithSchema() {
+      return new GenericRowWithSchema(values, schema);
+    }
+  }
+}


### PR DESCRIPTION
This is the first step in refactoring the code to be shared between GBIF and ALA.

This change adds an interface for accessing the OccurrenceFeatures, and an implementation using of this against a Spark Row (as it was).

A Pojo implementation is added in the Test folder (using a verbose builder to avoid bring the new style to this project). The tests are repeated on both the Spark version (as they originally were) and the Pojo version.

My intention is to release this in occurrence and then move the code to pipelines and remove it from this project. I wish to split the refactor and the move into two steps to avoid changing too many things in one go. 

Note: The code will be reformated to the google code style during moving to pipelines, and the use of lombok will be added in that move.

@MattBlissett - happy to take a call to orient you on the changes before you review.
