### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/occurrence-download/example-jobs/download-from-openstreetmap-polygon.sh
+++ b/occurrence-download/example-jobs/download-from-openstreetmap-polygon.sh
@@ -7,7 +7,7 @@
 
 id=$1
 
-[[ -f $id.xml ]] || curl -Ssfo $id.xml https://www.openstreetmap.org/api/0.6/relation/$id/full
+[[ -f $id.xml ]] || curl -Ssfo $id.xml https://api.openstreetmap.org/api/0.6/relation/$id/full
 
 ogr2ogr -f CSV $id.csv $id.xml -lco GEOMETRY=AS_WKT multipolygons
 


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)

cc: @MattBlissett 