### PR TITLE
Apply curator patched jar

### DIFF
--- a/occurrence-download-launcher/pom.xml
+++ b/occurrence-download-launcher/pom.xml
@@ -198,6 +198,10 @@
       <artifactId>hadoop-common</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-reload4j</artifactId>
         </exclusion>

--- a/occurrence-ws/pom.xml
+++ b/occurrence-ws/pom.xml
@@ -327,6 +327,10 @@
       <artifactId>spring-cloud-starter-zookeeper-discovery</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@
       <url>https://repository.gbif.org/repository/thirdparty/</url>
     </repository>
     <repository>
+      <id>gbif-thirdparty-snapshot</id>
+      <url>https://repository.gbif.org/repository/thirdparty-snapshot/</url>
+    </repository>
+    <repository>
       <id>typesafe</id>
       <name>Typesafe Repository</name>
       <url>https://repo.typesafe.com/typesafe/maven-releases/</url>
@@ -148,6 +152,7 @@
     <commons-io.version>2.4</commons-io.version>
     <commmons-lang.version>3.12.0</commmons-lang.version>
     <curator.version>5.5.0</curator.version>
+    <curator-framework.version>5.5.0-disable-connectstr-updates</curator-framework.version>
     <curator-test.version>5.5.0</curator-test.version>
     <dbunit.version>2.4.9</dbunit.version>
     <geotools.version>20.5</geotools.version>
@@ -1119,7 +1124,7 @@
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-framework</artifactId>
-        <version>${curator.version}</version>
+        <version>${curator-framework.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>


### PR DESCRIPTION
This applies the patched jar to occurrence-ws and occurrence-download-launcher to ensure ZK reconnection in the event of an outage (eg. zk restarting)

