### PR TITLE
Fix for ES mappings for eventID and others

### DIFF
--- a/occurrence-es-mapping/src/main/java/org/gbif/event/search/es/EventEsField.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/event/search/es/EventEsField.java
@@ -53,26 +53,26 @@ public enum EventEsField implements EsField {
   PROGRAMME(new BaseEsField("metadata.programmeAcronym", GbifInternalTerm.programmeAcronym)),
 
   //Core identification
-  INSTITUTION_CODE(new BaseEsField("event.institutionCode", DwcTerm.institutionCode, true)),
-  COLLECTION_CODE(new BaseEsField("event.collectionCode", DwcTerm.collectionCode, true)),
-  CATALOG_NUMBER(new BaseEsField("event.catalogNumber", DwcTerm.catalogNumber, true)),
+  INSTITUTION_CODE(new BaseEsField("event.institutionCode", DwcTerm.institutionCode, true, true)),
+  COLLECTION_CODE(new BaseEsField("event.collectionCode", DwcTerm.collectionCode, true, true)),
+  CATALOG_NUMBER(new BaseEsField("event.catalogNumber", DwcTerm.catalogNumber, true, true)),
 
-  ORGANISM_ID(new BaseEsField("event.organismId", DwcTerm.organismID, true)),
-  OCCURRENCE_ID(new BaseEsField("event.occurrenceId", DwcTerm.occurrenceID, true)),
-  RECORDED_BY(new BaseEsField("event.recordedBy", DwcTerm.recordedBy, true)),
-  IDENTIFIED_BY(new BaseEsField("event.identifiedBy", DwcTerm.identifiedBy, true)),
+  ORGANISM_ID(new BaseEsField("event.organismId", DwcTerm.organismID, true, true)),
+  OCCURRENCE_ID(new BaseEsField("event.occurrenceId", DwcTerm.occurrenceID, true, true)),
+  RECORDED_BY(new BaseEsField("event.recordedBy", DwcTerm.recordedBy, true, true)),
+  IDENTIFIED_BY(new BaseEsField("event.identifiedBy", DwcTerm.identifiedBy, true, true)),
   RECORDED_BY_ID(new BaseEsField("event.recordedByIds", "event.recordedByIds.value", DwcTerm.recordedByID)),
   IDENTIFIED_BY_ID(new BaseEsField("event.identifiedByIds", "event.identifiedByIds.value", DwcTerm.identifiedByID)),
-  RECORD_NUMBER(new BaseEsField("event.recordNumber", DwcTerm.recordNumber, true)),
+  RECORD_NUMBER(new BaseEsField("event.recordNumber", DwcTerm.recordNumber, true, true)),
   BASIS_OF_RECORD(new BaseEsField("event.basisOfRecord", DwcTerm.basisOfRecord)),
   TYPE_STATUS(new BaseEsField("event.typeStatus.lineage", "typeStatus.concept", DwcTerm.typeStatus)),
   OCCURRENCE_STATUS(new BaseEsField("event.occurrenceStatus", DwcTerm.occurrenceStatus)),
   IS_SEQUENCED(new BaseEsField("event.isSequenced", GbifTerm.isSequenced)),
   ASSOCIATED_SEQUENCES(new BaseEsField("event.associatedSequences", DwcTerm.associatedSequences)),
   DATASET_ID(new BaseEsField("event.datasetID", DwcTerm.datasetID)),
-  DATASET_NAME(new BaseEsField("event.datasetName", DwcTerm.datasetName, true)),
-  OTHER_CATALOG_NUMBERS(new BaseEsField("event.otherCatalogNumbers", DwcTerm.otherCatalogNumbers, true)),
-  PREPARATIONS(new BaseEsField("event.preparations", DwcTerm.preparations, true)),
+  DATASET_NAME(new BaseEsField("event.datasetName", DwcTerm.datasetName, true, true)),
+  OTHER_CATALOG_NUMBERS(new BaseEsField("event.otherCatalogNumbers", DwcTerm.otherCatalogNumbers, true, true)),
+  PREPARATIONS(new BaseEsField("event.preparations", DwcTerm.preparations, true, true)),
 
   //Temporal
   YEAR(new BaseEsField("event.year", DwcTerm.year)),
@@ -96,9 +96,9 @@ public enum EventEsField implements EsField {
   DEPTH_ACCURACY(new BaseEsField("event.depthAccuracy", GbifTerm.depthAccuracy)),
   ELEVATION(new BaseEsField("event.elevation", GbifTerm.elevation)),
   DEPTH(new BaseEsField("event.depth", GbifTerm.depth)),
-  STATE_PROVINCE(new BaseEsField("event.stateProvince", DwcTerm.stateProvince, true)), //NOT INTERPRETED
-  WATER_BODY(new BaseEsField("event.waterBody", DwcTerm.waterBody, true)),
-  LOCALITY(new BaseEsField("event.locality", DwcTerm.locality, true)),
+  STATE_PROVINCE(new BaseEsField("event.stateProvince", DwcTerm.stateProvince, true, true)), //NOT INTERPRETED
+  WATER_BODY(new BaseEsField("event.waterBody", DwcTerm.waterBody, true, true)),
+  LOCALITY(new BaseEsField("event.locality", DwcTerm.locality, true, true)),
   COORDINATE_PRECISION(new BaseEsField("event.coordinatePrecision", DwcTerm.coordinatePrecision)),
   COORDINATE_UNCERTAINTY_IN_METERS(new BaseEsField("event.coordinateUncertaintyInMeters", DwcTerm.coordinateUncertaintyInMeters)),
   DISTANCE_FROM_CENTROID_IN_METERS(new BaseEsField("event.distanceFromCentroidInMeters", GbifTerm.distanceFromCentroidInMeters)),
@@ -158,10 +158,10 @@ public enum EventEsField implements EsField {
   INSTITUTION_KEY(new BaseEsField("event.institutionKey", GbifInternalTerm.institutionKey)),
 
   //Sampling
-  EVENT_ID(new BaseEsField("event.eventID", DwcTerm.eventID, true)),
-  PARENT_EVENT_ID(new BaseEsField("event.parentEventID", DwcTerm.parentEventID, true)),
-  EVENT_ID_HIERARCHY(new BaseEsField("event.eventHierarchy", null, true)),
-  SAMPLING_PROTOCOL(new BaseEsField("event.samplingProtocol", DwcTerm.samplingProtocol, true)),
+  EVENT_ID(new BaseEsField("event.eventID", DwcTerm.eventID, true, true)),
+  PARENT_EVENT_ID(new BaseEsField("event.parentEventID", DwcTerm.parentEventID, true,true)),
+  EVENT_ID_HIERARCHY(new BaseEsField("event.eventHierarchy", null, true,true)),
+  SAMPLING_PROTOCOL(new BaseEsField("event.samplingProtocol", DwcTerm.samplingProtocol, true,true)),
   LIFE_STAGE(new BaseEsField("event.lifeStage.lineage", "lifeStage.concept", DwcTerm.lifeStage)),
   DATE_IDENTIFIED(new BaseEsField("event.dateIdentified", DwcTerm.dateIdentified)),
   MODIFIED(new BaseEsField("event.modified", DcTerm.modified)),
@@ -349,5 +349,10 @@ public enum EventEsField implements EsField {
   @Override
   public boolean isAutoSuggest() {
     return esField.isAutoSuggest();
+  }
+
+  @Override
+  public boolean isUsingText() {
+    return esField.isUsingText();
   }
 }

--- a/occurrence-es-mapping/src/main/java/org/gbif/event/search/es/OccurrenceEventEsField.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/event/search/es/OccurrenceEventEsField.java
@@ -37,8 +37,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import static org.gbif.occurrence.search.es.OccurrenceEsField.PUBLISHED_BY_GBIF_REGION;
-
 /** Enum that contains the mapping of symbolic names and field names of valid Elasticsearch fields. */
 public enum OccurrenceEventEsField implements EsField {
 
@@ -421,4 +419,8 @@ public enum OccurrenceEventEsField implements EsField {
     return esField.isAutoSuggest();
   }
 
+  @Override
+  public boolean isUsingText() {
+    return esField.isUsingText();
+  }
 }

--- a/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/BaseEsField.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/BaseEsField.java
@@ -33,11 +33,15 @@ public class BaseEsField implements EsField {
   @Getter(onMethod = @__({@Override}))
   private boolean autoSuggest;
 
+  @Getter(onMethod = @__({@Override}))
+  private boolean usingText;
+
   public BaseEsField(String searchFieldName, String valueFieldName, Term term) {
     this.searchFieldName = searchFieldName;
     this.term = term;
     this.autoSuggest = false;
     this.valueFieldName = valueFieldName;
+    this.usingText = false;
   }
 
   public BaseEsField(String searchFieldName, Term term) {
@@ -45,6 +49,7 @@ public class BaseEsField implements EsField {
     this.term = term;
     this.autoSuggest = false;
     this.valueFieldName = searchFieldName;
+    this.usingText = false;
   }
 
   public BaseEsField(String searchFieldName, Term term, boolean autoSuggest) {
@@ -52,6 +57,14 @@ public class BaseEsField implements EsField {
     this.term = term;
     this.autoSuggest = autoSuggest;
     this.valueFieldName = searchFieldName;
+    this.usingText = false;
   }
 
+  public BaseEsField(String searchFieldName, Term term, boolean autoSuggest, boolean usingText) {
+    this.searchFieldName = searchFieldName;
+    this.term = term;
+    this.autoSuggest = autoSuggest;
+    this.valueFieldName = searchFieldName;
+    this.usingText = usingText;
+  }
 }

--- a/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/EsField.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/EsField.java
@@ -31,20 +31,22 @@ public interface EsField {
   String getValueFieldName();
 
   default String getExactMatchFieldName() {
-    return getSearchFieldName();
+    return isAutoSuggest() && isUsingText()? getSearchFieldName() + ".keyword" : getSearchFieldName();
   }
 
   default String getVerbatimFieldName() {
-    return isAutoSuggest()? getSearchFieldName() + ".verbatim" : getSearchFieldName();
+    return isAutoSuggest() ? getSearchFieldName() + ".verbatim" : getSearchFieldName();
   }
 
   default String getSuggestFieldName() {
-    return isAutoSuggest()? getSearchFieldName() + ".suggest" : getSearchFieldName();
+    return isAutoSuggest() ? getSearchFieldName() + ".suggest" : getSearchFieldName();
   }
 
   Term getTerm();
 
   boolean isAutoSuggest();
+
+  boolean isUsingText();
 
   default boolean isChildField() {
     return false;

--- a/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/OccurrenceEsField.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/OccurrenceEsField.java
@@ -237,8 +237,8 @@ public enum OccurrenceEsField implements EsField {
   MEMBER(new BaseEsField("geologicalContext.member", DwcTerm.member)),
   BED(new BaseEsField("geologicalContext.bed", DwcTerm.bed)),
   GEOLOGICAL_TIME(new BaseEsField("geologicalContext.range", null)),
-  LITHOSTRATIGRAPHY(new BaseEsField("geologicalContext.lithostratigraphy", null, true)),
-  BIOSTRATIGRAPHY(new BaseEsField("geologicalContext.biostratigraphy", null, true)),
+  LITHOSTRATIGRAPHY(new BaseEsField("geologicalContext.lithostratigraphy", null, true, true)),
+  BIOSTRATIGRAPHY(new BaseEsField("geologicalContext.biostratigraphy", null, true, true)),
 
   MODIFIED(new BaseEsField("modified", DcTerm.modified)),
   REFERENCES(new BaseEsField("references", DcTerm.references)),
@@ -468,5 +468,10 @@ public enum OccurrenceEsField implements EsField {
   @Override
   public boolean isAutoSuggest() {
     return esField.isAutoSuggest();
+  }
+
+  @Override
+  public boolean isUsingText() {
+    return esField.isUsingText();
   }
 }


### PR DESCRIPTION
this adds a `isUsingText` field to ESField to accomodate field that support autosuggest but are using `text` in the elastic schema instead of the default choice `keyword`

Most of the fields in the occurrence elastic schema have been re-mapped to `keyword` where previously `text` was used.
The same isnt true currently for the corresponding fields in the event elastic schema.