### PR TITLE
Changes to allow downloading of records with a specified taxonomy. 

### DIFF
--- a/event-ws/src/main/java/org/gbif/event/search/es/EventSearchEs.java
+++ b/event-ws/src/main/java/org/gbif/event/search/es/EventSearchEs.java
@@ -107,7 +107,7 @@ public class EventSearchEs implements SearchService<Event, OccurrenceSearchParam
     occurrenceEsFieldMapper = OccurrenceEventEsField.buildFieldMapper();
     this.esSearchRequestBuilder = new EsSearchRequestBuilder(eventEsFieldMapper, conceptClient, nameUsageMatchingService);
     searchHitEventConverter = new SearchHitEventConverter(eventEsFieldMapper, true);
-    searchHitOccurrenceConverter = new SearchHitOccurrenceConverter(occurrenceEsFieldMapper, true, defaultChecklistKey);
+    searchHitOccurrenceConverter = new SearchHitOccurrenceConverter(occurrenceEsFieldMapper, true);
     this.esResponseParser = new EsResponseParser<>(eventEsFieldMapper, searchHitEventConverter);
   }
 

--- a/occurrence-cli/src/main/java/org/gbif/occurrence/cli/dataset/EsDatasetDeleterConfiguration.java
+++ b/occurrence-cli/src/main/java/org/gbif/occurrence/cli/dataset/EsDatasetDeleterConfiguration.java
@@ -19,9 +19,9 @@ import org.gbif.occurrence.cli.common.GangliaConfiguration;
 import java.util.Arrays;
 import java.util.StringJoiner;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;

--- a/occurrence-cli/src/main/java/org/gbif/occurrence/cli/registry/service/RegistryChangeConfiguration.java
+++ b/occurrence-cli/src/main/java/org/gbif/occurrence/cli/registry/service/RegistryChangeConfiguration.java
@@ -15,8 +15,8 @@ package org.gbif.occurrence.cli.registry.service;
 
 import org.gbif.common.messaging.config.MessagingConfiguration;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;

--- a/occurrence-common/src/main/java/org/gbif/occurrence/common/TermUtils.java
+++ b/occurrence-common/src/main/java/org/gbif/occurrence/common/TermUtils.java
@@ -105,8 +105,8 @@ public class TermUtils {
     GbifTerm.livingPeriod,
     GbifTerm.lifeForm,
     GbifTerm.ageInDays,
-    GbifTerm.sizeInMillimeter,
-    GbifTerm.massInGram,
+    GbifTerm.sizeInMillimeters,
+    GbifTerm.massInGrams,
     GbifTerm.organismPart,
     GbifTerm.appendixCITES,
     GbifTerm.typeDesignatedBy,
@@ -143,6 +143,48 @@ public class TermUtils {
   private static final Map<Term,String> TERMS_IDENTICAL_AFTER_INTERPRETATION = ImmutableMap.<Term,String>builder()
       .put(DwcTerm.geodeticDatum, Occurrence.GEO_DATUM)
       .build();
+
+  /**
+   * The terms that are present only due to explicit interpretation.  These are often typed explicitly, such as Dates
+   * or are the result of a routine that has analyzed various verbatim fields and interpreted them into new values,
+   * such as the dwc:kingdom ... dwc:scientificName fields which are subject to a NUB lookup.
+   *
+   * <p>These are all explicit Java properties on the {@link org.gbif.api.model.occurrence.Occurrence} class.
+   */
+  private static final Set<Term> TAXON_TERMS_POPULATED_BY_INTERPRETATION = ImmutableSet.of(
+    DwcTerm.kingdom,
+    DwcTerm.phylum,
+    DwcTerm.class_,
+    DwcTerm.order,
+    DwcTerm.superfamily,
+    DwcTerm.family,
+    DwcTerm.subfamily,
+    DwcTerm.tribe,
+    DwcTerm.subtribe,
+    DwcTerm.genus,
+    DwcTerm.subgenus,
+    GbifTerm.species,
+    DwcTerm.scientificName,
+    DwcTerm.taxonRank,
+    DwcTerm.taxonomicStatus,
+    GbifTerm.acceptedScientificName,
+    DwcTerm.genericName,
+    DwcTerm.specificEpithet,
+    DwcTerm.infraspecificEpithet,
+    DwcTerm.infragenericEpithet,
+    GbifTerm.taxonKey,
+    GbifTerm.acceptedTaxonKey,
+    GbifTerm.kingdomKey,
+    GbifTerm.phylumKey,
+    GbifTerm.classKey,
+    GbifTerm.orderKey,
+    GbifTerm.familyKey,
+    GbifTerm.genusKey,
+    GbifTerm.subgenusKey,
+    GbifTerm.speciesKey,
+    GbifTerm.taxonomicIssue,
+    IucnTerm.iucnRedListCategory
+    );
 
   /**
    * The terms that are present only due to explicit interpretation.  These are often typed explicitly, such as Dates
@@ -433,6 +475,10 @@ public class TermUtils {
    */
   public static boolean isInterpretedLocalDateSeconds(Term term) {
     return SQLColumnsUtils.isInterpretedLocalDateSeconds(term);
+  }
+
+  public static boolean isTaxonomic(Term term) {
+    return TAXON_TERMS_POPULATED_BY_INTERPRETATION.contains(term);
   }
 
   /**

--- a/occurrence-download/pom.xml
+++ b/occurrence-download/pom.xml
@@ -172,6 +172,14 @@
           </argLine>
         </configuration>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>17</source>
+                <target>17</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/action/DownloadWorkflowModule.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/action/DownloadWorkflowModule.java
@@ -13,7 +13,6 @@
  */
 package org.gbif.occurrence.download.action;
 
-import org.gbif.api.model.Constants;
 import org.gbif.api.model.event.Event;
 import org.gbif.api.model.occurrence.DownloadFormat;
 import org.gbif.api.model.occurrence.Occurrence;
@@ -90,13 +89,6 @@ public class DownloadWorkflowModule  {
   private final WorkflowConfiguration workflowConfiguration;
 
   private final DownloadJobConfiguration downloadJobConfiguration;
-
-  private final String defaultChecklistKey = Constants.NUB_DATASET_KEY.toString();
-
-  /**
-   * DownloadPrepare action factory method.
-   * This is the initial action that counts records and its output is used to decide if a download is processed through Hive or Es.
-   */
 
   /**
    * Creates a DownloadService for Event or Occurrence downloads.
@@ -219,10 +211,10 @@ public class DownloadWorkflowModule  {
     return highLevelClient;
   }
 
-  public static OccurrenceBaseEsFieldMapper esFieldMapper(WorkflowConfiguration.SearchType searchType,
-                                                          String defaultChecklistKey) {
+
+  public static OccurrenceBaseEsFieldMapper esFieldMapper(WorkflowConfiguration.SearchType searchType, String checklistKey) {
     return WorkflowConfiguration.SearchType.OCCURRENCE == searchType ?
-      OccurrenceEsField.buildFieldMapper(defaultChecklistKey) : EventEsField.buildFieldMapper();
+      OccurrenceEsField.buildFieldMapper(checklistKey) : EventEsField.buildFieldMapper();
   }
 
   /**
@@ -239,20 +231,27 @@ public class DownloadWorkflowModule  {
 
   private <T extends VerbatimOccurrence, S extends SearchHitConverter<T>> S searchHitConverter() {
     if (workflowConfiguration.getEsIndexType() == WorkflowConfiguration.SearchType.EVENT) {
-      return (S) new SearchHitEventConverter(esFieldMapper(workflowConfiguration.getEsIndexType(),workflowConfiguration.getDefaultChecklistKey()), false);
+      return (S) new SearchHitEventConverter(esFieldMapper(workflowConfiguration.getEsIndexType(),
+        downloadJobConfiguration.getChecklistKey() != null ? downloadJobConfiguration.getChecklistKey() : workflowConfiguration.getDefaultChecklistKey()
+      ), false);
     }
-    return (S) new SearchHitOccurrenceConverter(esFieldMapper(workflowConfiguration.getEsIndexType(), workflowConfiguration.getDefaultChecklistKey()), false, defaultChecklistKey);
+    return (S) new SearchHitOccurrenceConverter(esFieldMapper(workflowConfiguration.getEsIndexType(),
+      downloadJobConfiguration.getChecklistKey() != null ? downloadJobConfiguration.getChecklistKey() : workflowConfiguration.getDefaultChecklistKey()
+    ), false);
   }
 
   private <T extends VerbatimOccurrence> Function<T, Map<String,String>> verbatimMapper(){
-    return  OccurrenceMapReader::buildVerbatimOccurrenceMap;
+    return OccurrenceMapReader::buildVerbatimOccurrenceMap;
   }
 
   private <T extends VerbatimOccurrence> Function<T, Map<String,String>> interpreterMapper() {
     if (workflowConfiguration.getEsIndexType() == WorkflowConfiguration.SearchType.EVENT) {
-      return (T record) -> OccurrenceMapReader.buildInterpretedEventMap((Event)record);
+      return (T record) -> OccurrenceMapReader.buildInterpretedEventMap((Event) record);
     }
-    return  (T record) -> OccurrenceMapReader.buildInterpretedOccurrenceMap((Occurrence) record);
+    return (T record) -> OccurrenceMapReader.buildInterpretedOccurrenceMap((Occurrence) record,
+      downloadJobConfiguration.getChecklistKey() != null ?
+        downloadJobConfiguration.getChecklistKey() : workflowConfiguration.getDefaultChecklistKey()
+    );
   }
 
   /** Creates an ActorRef that holds an instance of {@link DownloadMaster}. */

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/conf/DownloadJobConfiguration.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/conf/DownloadJobConfiguration.java
@@ -43,6 +43,7 @@ import lombok.Data;
 public class DownloadJobConfiguration {
 
   private static final Logger log = LoggerFactory.getLogger(DownloadJobConfiguration.class);
+
   /** Occurrence download key/identifier. */
   private final String downloadKey;
 
@@ -74,7 +75,7 @@ public class DownloadJobConfiguration {
   private final Set<Extension> extensions;
 
   /** Requested extensions. */
-  private final String defaultChecklistKey;
+  private final String checklistKey;
 
   @Builder
   private DownloadJobConfiguration(
@@ -88,7 +89,7 @@ public class DownloadJobConfiguration {
       DownloadFormat downloadFormat,
       DwcTerm coreTerm,
       Set<Extension> extensions,
-      String defaultChecklistKey) {
+      String checklistKey) {
     this.downloadKey = downloadKey;
     this.filter = filter;
     this.user = user;
@@ -99,10 +100,11 @@ public class DownloadJobConfiguration {
     this.downloadFormat = downloadFormat;
     this.coreTerm = coreTerm;
     this.extensions = extensions;
-    this.defaultChecklistKey = defaultChecklistKey;
+    this.checklistKey = checklistKey;
   }
 
-  public static DownloadJobConfiguration forSqlDownload(Download download, String sourceDir) {
+  public static DownloadJobConfiguration forSqlDownload(Download download,
+                                                        WorkflowConfiguration workflowConfiguration) {
     return DownloadJobConfiguration.builder()
         .downloadKey(download.getKey())
         .downloadFormat(download.getRequest().getFormat())
@@ -111,7 +113,10 @@ public class DownloadJobConfiguration {
         .filter(getDownloadFilter(download))
         .downloadTableName(DownloadUtils.downloadTableName(download.getKey()))
         .isSmallDownload(false)
-        .sourceDir(sourceDir)
+        .sourceDir(workflowConfiguration.getHiveDBPath())
+        .checklistKey(download.getRequest().getChecklistKey() != null
+            ? download.getRequest().getChecklistKey()
+            : workflowConfiguration.getDefaultChecklistKey())
         .build();
   }
 
@@ -126,7 +131,7 @@ public class DownloadJobConfiguration {
 
   public OccurrenceBaseEsFieldMapper esFieldMapper(Download download) {
     return DownloadType.OCCURRENCE == download.getRequest().getType()
-        ? OccurrenceEsField.buildFieldMapper(defaultChecklistKey)
+        ? OccurrenceEsField.buildFieldMapper(checklistKey)
         : EventEsField.buildFieldMapper();
   }
 

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/conf/WorkflowConfiguration.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/conf/WorkflowConfiguration.java
@@ -13,8 +13,8 @@
  */
 package org.gbif.occurrence.download.conf;
 
+import org.gbif.api.model.Constants;
 import org.gbif.api.model.occurrence.DownloadFormat;
-import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.occurrence.common.download.DownloadUtils;
 import org.gbif.occurrence.download.action.DownloadWorkflowModule;
 import org.gbif.utils.file.properties.PropertiesUtil;
@@ -115,11 +115,12 @@ public class WorkflowConfiguration {
 
   /**
    *
-   * @return local temp dir where downloads files are created
+   * @return the default checklist key used for the download if no checklistKey is provided
    */
   public String getDefaultChecklistKey() {
     Preconditions.checkNotNull(settings);
-    return settings.getProperty(DownloadWorkflowModule.DefaultSettings.DEFAULT_CHECKLIST_KEY);
+    return settings.getProperty(DownloadWorkflowModule.DefaultSettings.DEFAULT_CHECKLIST_KEY,
+      Constants.NUB_DATASET_KEY.toString());
   }
 
   /**

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/file/DownloadMaster.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/file/DownloadMaster.java
@@ -103,7 +103,10 @@ public class DownloadMaster<T extends Occurrence> extends AbstractActor {
     SearchHitConverter<T> searchHitConverter) {
     conf = masterConfiguration;
     this.jobConfiguration = jobConfiguration;
-    DownloadWorkflowModule downloadWorkflowModule = DownloadWorkflowModule.builder().workflowConfiguration(workflowConfiguration).downloadJobConfiguration(jobConfiguration).build();
+    DownloadWorkflowModule downloadWorkflowModule = DownloadWorkflowModule.builder()
+      .workflowConfiguration(workflowConfiguration)
+      .downloadJobConfiguration(jobConfiguration)
+      .build();
     this.curatorFramework = downloadWorkflowModule.curatorFramework();
     this.lockFactory = new ZooKeeperLockFactory(curatorFramework,
                                                 maxGlobalJobs,
@@ -112,7 +115,8 @@ public class DownloadMaster<T extends Occurrence> extends AbstractActor {
     this.esIndex = esIndex;
     this.aggregator = aggregator;
     this.occurrenceBaseEsFieldMapper = DownloadWorkflowModule.esFieldMapper(
-      workflowConfiguration.getEsIndexType(), workflowConfiguration.getDefaultChecklistKey());
+      workflowConfiguration.getEsIndexType(), jobConfiguration.getChecklistKey()
+    );
     this.interpretedMapper = interpretedMapper;
     this.verbatimMapper = verbatimMapper;
     this.searchHitConverter = searchHitConverter;

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/AvroQueries.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/AvroQueries.java
@@ -28,7 +28,7 @@ public class AvroQueries extends TsvQueries {
   }
 
   @Override
-  String toInterpretedHiveInitializer(Term term) {
+  String toInterpretedHiveInitializer(Term term, String checklistKey) {
     if (TermUtils.isInterpretedLocalDateSeconds(term)) {
       return secondsToLocalISO8601Initializer(term);
     } else if (TermUtils.isInterpretedUtcDateSeconds(term)) {

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/AvroSchemaQueries.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/AvroSchemaQueries.java
@@ -39,7 +39,7 @@ class AvroSchemaQueries extends Queries {
   }
 
   @Override
-  String toInterpretedHiveInitializer(Term term) {
+  String toInterpretedHiveInitializer(Term term, String checklistKey) {
     return term.simpleName();
   }
 

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/HiveQueries.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/HiveQueries.java
@@ -29,8 +29,10 @@ public class HiveQueries extends TsvQueries {
   }
 
   @Override
-  String toInterpretedHiveInitializer(Term term) {
-    if (TermUtils.isInterpretedLocalDateSeconds(term)) {
+  String toInterpretedHiveInitializer(Term term, String checklistKey) {
+    if (TermUtils.isTaxonomic(term)) {
+      return toTaxonomicHiveInitializer(term, checklistKey);
+    } else if (TermUtils.isInterpretedLocalDateSeconds(term)) {
       return secondsToLocalISO8601Initializer(term);
     } else if (TermUtils.isVocabulary(term)) {
       return toVocabularyConceptHiveInitializer(term);

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/ParquetQueries.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/ParquetQueries.java
@@ -40,7 +40,7 @@ class ParquetQueries extends Queries {
   }
 
   @Override
-  String toInterpretedHiveInitializer(Term term) {
+  String toInterpretedHiveInitializer(Term term, String checklistKey) {
     if (TermUtils.isInterpretedLocalDateSeconds(term)
         || TermUtils.isInterpretedUtcDateSeconds(term)
         || TermUtils.isInterpretedUtcDateMilliseconds(term)) {

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/ParquetSchemaQueries.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/ParquetSchemaQueries.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 
 
 /**
- * Utilities related to the actual queries executed at runtime — these functions for generating AVRO downloads.
+ * Utilities related to the actual queries executed at runtime — these functions for generating Parquet downloads.
  */
 class ParquetSchemaQueries extends Queries {
 
@@ -59,7 +59,7 @@ class ParquetSchemaQueries extends Queries {
   }
 
   @Override
-  String toInterpretedHiveInitializer(Term term) {
+  String toInterpretedHiveInitializer(Term term, String checklistKey) {
     return term.simpleName().toLowerCase(Locale.ROOT);
   }
 }

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/Queries.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/Queries.java
@@ -93,8 +93,8 @@ public abstract class Queries {
    * @param useInitializers whether to convert dates, arrays etc to strings
    * @return the select fields for the interpreted download fields
    */
-  public Map<String, InitializableField> selectInterpretedFields(boolean useInitializers) {
-    return selectDownloadFields(DownloadTerms.DOWNLOAD_INTERPRETED_TERMS, useInitializers);
+  public Map<String, InitializableField> selectInterpretedFields(boolean useInitializers, String checklistKey) {
+    return selectDownloadFields(DownloadTerms.DOWNLOAD_INTERPRETED_TERMS, useInitializers, checklistKey);
   }
 
   /**
@@ -107,25 +107,21 @@ public abstract class Queries {
 
   /**
    * @param useInitializers whether to convert dates, arrays etc to strings
-   * @return the select fields for the internal download fields
-   */
-  Map<String, InitializableField> selectInternalFields(boolean useInitializers) {
-    return selectDownloadFields(DownloadTerms.INTERNAL_DOWNLOAD_TERMS, useInitializers);
-  }
-
-  /**
-   * @param useInitializers whether to convert dates, arrays etc to strings
    * @return the select fields for the internal search fields
    */
   public Map<String, InitializableField> selectInternalSearchFields(boolean useInitializers) {
     return selectDownloadFields(DownloadTerms.INTERNAL_SEARCH_TERMS, useInitializers);
   }
 
+  Map<String, InitializableField> selectDownloadFields(Set<Term> terms, boolean useInitializers) {
+    return selectDownloadFields(terms, useInitializers, null);
+  }
+
   /**
    * @param useInitializers whether to convert dates, arrays etc to strings
    * @return the select fields for the interpreted download fields
    */
-  Map<String, InitializableField> selectDownloadFields(Set<Term> terms, boolean useInitializers) {
+  Map<String, InitializableField> selectDownloadFields(Set<Term> terms, boolean useInitializers, String checklistKey) {
     Map<String, InitializableField> result = new LinkedHashMap<>();
 
     // always add the GBIF ID
@@ -145,7 +141,7 @@ public abstract class Queries {
       } else {
         result.put(term.simpleName(), new InitializableField(
           term,
-          useInitializers ? toInterpretedHiveInitializer(term) : toHiveInitializer(term),
+          useInitializers ? toInterpretedHiveInitializer(term, checklistKey) : toHiveInitializer(term),
           toHiveDataType(term)
         ));
       }
@@ -162,7 +158,7 @@ public abstract class Queries {
   /**
    * @return The initializer for an interpreted field, e.g. genus, toISO8601(eventdate) AS eventdate
    */
-  abstract String toInterpretedHiveInitializer(Term term);
+  abstract String toInterpretedHiveInitializer(Term term, String checklistKey);
 
   /**
    * Used for complex types like Structs which have nested elements.
@@ -212,8 +208,8 @@ public abstract class Queries {
    * @param useInitializers whether to convert dates, arrays etc to strings
    * @return the select fields for the simple download fields
    */
-  public Map<String, InitializableField> selectSimpleDownloadFields(boolean useInitializers) {
-    return selectGroupedDownloadFields(DownloadTerms.SIMPLE_DOWNLOAD_TERMS, useInitializers);
+  public Map<String, InitializableField> selectSimpleDownloadFields(boolean useInitializers, String checklistKey) {
+    return selectGroupedDownloadFields(DownloadTerms.SIMPLE_DOWNLOAD_TERMS, useInitializers, checklistKey);
   }
 
   /**
@@ -221,7 +217,8 @@ public abstract class Queries {
    * @return the select fields for the simple-with-verbatim download fields
    */
   Map<String, InitializableField> selectSimpleWithVerbatimDownloadFields(boolean useInitializers) {
-    return selectGroupedDownloadFields(DownloadTerms.SIMPLE_WITH_VERBATIM_DOWNLOAD_TERMS, useInitializers);
+    return selectGroupedDownloadFields(DownloadTerms.SIMPLE_WITH_VERBATIM_DOWNLOAD_TERMS,
+      useInitializers, null);
   }
 
   public Map<String, InitializableField> simpleWithVerbatimAvroQueryFields(boolean useInitializers) {
@@ -240,7 +237,10 @@ public abstract class Queries {
    * @param useInitializers whether to convert dates, arrays etc to strings
    * @return the select fields for the (mostly) interpreted table in the simple download
    */
-  Map<String, InitializableField> selectGroupedDownloadFields(Set<Pair<DownloadTerms.Group, Term>> termPairs, boolean useInitializers) {
+  Map<String, InitializableField> selectGroupedDownloadFields(Set<Pair<DownloadTerms.Group, Term>> termPairs,
+                                                              boolean useInitializers,
+                                                              String checklistKey) {
+
     Map<String, InitializableField> result = new LinkedHashMap<>();
 
     // always add the GBIF ID
@@ -261,7 +261,7 @@ public abstract class Queries {
       } else {
         result.put(term.simpleName(), new InitializableField(
           term,
-          useInitializers ? toInterpretedHiveInitializer(term) : toHiveInitializer(term),
+          useInitializers ? toInterpretedHiveInitializer(term, checklistKey) : toHiveInitializer(term),
           toHiveDataType(term)
         ));
       }

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/TsvQueries.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/TsvQueries.java
@@ -13,6 +13,7 @@
  */
 package org.gbif.occurrence.download.hive;
 
+import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.dwc.terms.Term;
 
 import java.util.Locale;
@@ -38,6 +39,28 @@ abstract class TsvQueries extends Queries {
   protected static String secondsToLocalISO8601Initializer(Term term) {
     final String column = HiveColumns.columnFor(term);
     return "secondsToLocalISO8601(" + column + ") AS " + column;
+  }
+
+  protected static String toTaxonomicHiveInitializer(Term term, String checklistKey) {
+    if (checklistKey == null || checklistKey.isEmpty()) {
+      throw new IllegalArgumentException("checklistKey must not be null or empty");
+    }
+
+    if (term == DwcTerm.order) {
+      // Special case for keyword order
+      return String.format(
+        "element_at(element_at(classificationdetails, '%s'), 'order') AS `order`",
+        checklistKey
+      );
+    }
+
+    final String columnName = HiveColumns.columnFor(term);
+    return String.format(
+      "element_at(element_at(classificationdetails, '%s'), '%s') AS %s",
+      checklistKey,
+      columnName,
+      columnName
+    );
   }
 
   /**

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/spark/GbifOccurrenceDownloads.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/spark/GbifOccurrenceDownloads.java
@@ -37,13 +37,15 @@ public class GbifOccurrenceDownloads {
 
     WorkflowConfiguration workflowConfiguration =
         new WorkflowConfiguration(PropertiesUtil.readFromFile(propertiesFile));
+
     SparkDownloadWorkflow.builder()
         .downloadKey(downloadKey)
         .coreDwcTerm(dwcTerm)
         .downloadStage(downloadStage)
         .workflowConfiguration(workflowConfiguration)
         .queryExecutorSupplier(
-            () -> new SparkQueryExecutor(createSparkSession(downloadKey, workflowConfiguration)))
+            () -> new SparkQueryExecutor(createSparkSession(downloadKey, workflowConfiguration))
+        )
         .build()
         .run();
   }

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/spark/SparkDownloadWorkflow.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/spark/SparkDownloadWorkflow.java
@@ -53,8 +53,10 @@ public class SparkDownloadWorkflow {
   public void run() {
     if (DownloadStage.CLEANUP != downloadStage) {
       Download download = getDownload();
+
       DownloadJobConfiguration jobConfiguration =
-          DownloadJobConfiguration.forSqlDownload(download, workflowConfiguration.getHiveDBPath());
+          DownloadJobConfiguration.forSqlDownload(download, workflowConfiguration);
+
       DownloadQueryParameters queryParameters =
           DownloadQueryParameters.from(download, jobConfiguration, workflowConfiguration);
 
@@ -63,6 +65,9 @@ public class SparkDownloadWorkflow {
             .download(download)
             .queryExecutorSupplier(queryExecutorSupplier)
             .queryParameters(queryParameters)
+            .checklistKey(download.getRequest().getChecklistKey() !=null ?
+              download.getRequest().getChecklistKey()
+              : workflowConfiguration.getDefaultChecklistKey())
             .build()
             .runDownloadQuery();
       }

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/sql/DownloadQueryParameters.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/sql/DownloadQueryParameters.java
@@ -49,6 +49,7 @@ public class DownloadQueryParameters {
       Download download,
       DownloadJobConfiguration jobConfiguration,
       WorkflowConfiguration workflowConfiguration) {
+
     DownloadQueryParameters.DownloadQueryParametersBuilder builder =
         DownloadQueryParameters.builder()
             .downloadTableName(jobConfiguration.getDownloadTableName())
@@ -56,6 +57,7 @@ public class DownloadQueryParameters {
             .tableName(jobConfiguration.getCoreTerm().name().toLowerCase())
             .database(workflowConfiguration.getHiveDb())
             .warehouseDir(workflowConfiguration.getHiveWarehouseDir());
+
     if (DownloadFormat.SQL_TSV_ZIP == jobConfiguration.getDownloadFormat()) {
       SqlValidation sv = new SqlValidation(workflowConfiguration.getHiveDb());
 

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/sql/DownloadQueryRunner.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/sql/DownloadQueryRunner.java
@@ -17,6 +17,7 @@ public class DownloadQueryRunner {
   private final Supplier<SparkQueryExecutor> queryExecutorSupplier;
   private final Download download;
   private final DownloadQueryParameters queryParameters;
+  private final String checklistKey;
 
   public void runDownloadQuery() {
     String downloadQuery = downloadQuery();
@@ -46,28 +47,22 @@ public class DownloadQueryRunner {
 
   @SneakyThrows
   private String downloadQuery() {
-    if (DownloadFormat.DWCA == download.getRequest().getFormat()) {
-      return SqlQueryUtils.queryTemplateToString(GenerateHQL::generateDwcaQueryHQL);
-    } else if (DownloadFormat.SPECIES_LIST == download.getRequest().getFormat()) {
-      return GenerateHQL.speciesListQueryHQL();
-    } else if (DownloadFormat.SIMPLE_CSV == download.getRequest().getFormat()) {
-      return GenerateHQL.simpleCsvQueryHQL();
-    } else if (DownloadFormat.SIMPLE_AVRO == download.getRequest().getFormat()) {
-      return GenerateHQL.simpleAvroQueryHQL();
-    } else if (DownloadFormat.SIMPLE_WITH_VERBATIM_AVRO == download.getRequest().getFormat()) {
-      return GenerateHQL.simpleWithVerbatimAvroQueryHQL();
-    } else if (DownloadFormat.SIMPLE_PARQUET == download.getRequest().getFormat()) {
-      return GenerateHQL.simpleParquetQueryHQL();
-    } else if (DownloadFormat.BIONOMIA == download.getRequest().getFormat()) {
-      return GenerateHQL.bionomiaQueryHQL();
-    } else if (DownloadFormat.MAP_OF_LIFE == download.getRequest().getFormat()) {
-      return GenerateHQL.mapOfLifeQueryHQL();
-    } else if (DownloadFormat.SQL_TSV_ZIP == download.getRequest().getFormat()) {
-      return GenerateHQL.sqlQueryHQL();
-    }
-
-    return null;
+    return switch (download.getRequest().getFormat()) {
+      case DWCA -> GenerateHQL.generateDwcaQueryHQL(checklistKey);
+      case SPECIES_LIST -> GenerateHQL.speciesListQueryHQL();
+      case SIMPLE_CSV -> GenerateHQL.simpleCsvQueryHQL(checklistKey);
+      case SIMPLE_AVRO -> GenerateHQL.simpleAvroQueryHQL(checklistKey);
+      case SIMPLE_WITH_VERBATIM_AVRO -> GenerateHQL.simpleWithVerbatimAvroQueryHQL();
+      case SIMPLE_PARQUET -> GenerateHQL.simpleParquetQueryHQL(checklistKey);
+      case BIONOMIA -> GenerateHQL.bionomiaQueryHQL();
+      case MAP_OF_LIFE -> GenerateHQL.mapOfLifeQueryHQL(checklistKey);
+      case SQL_TSV_ZIP -> GenerateHQL.sqlQueryHQL();
+      default ->
+        throw new IllegalArgumentException(
+          "Unsupported download format: " + download.getRequest().getFormat());
+    };
   }
+
 
   @SneakyThrows
   private String extensionQuery(Download download) {

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/sql/SqlQueryUtils.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/sql/SqlQueryUtils.java
@@ -15,8 +15,6 @@ package org.gbif.occurrence.download.sql;
 
 import java.io.StringWriter;
 import java.io.Writer;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
@@ -29,14 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 public class SqlQueryUtils {
 
   /**
-   * Reads a file into a string.
-   */
-  @SneakyThrows
-  private static String readFile(String fileName) {
-    return new String(Files.readAllBytes(Paths.get(fileName)));
-  }
-
-  /**
    * Replaces variables in the text. Variables come in a map of names and values.
    */
   private static String replaceVariables(String text, Map<String,String> params) {
@@ -44,14 +34,6 @@ public class SqlQueryUtils {
                                    params.keySet().stream().map(k -> "${" + k  + "}").toArray(String[]::new),
                                    params.values().toArray(new String[0]));
   }
-
-  /**
-   * Executes, statement-by-statement a file containing SQL queries.
-   */
-  public static void runSQLFile(String fileName, Map<String,String> params, BiConsumer<String, String> queryExecutor) {
-    runMultiSQL(fileName, readFile(fileName), params, queryExecutor);
-  }
-
 
   /**
    * Executes, statement-by-statement a String that contains multiple SQL queries.

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/util/SqlValidation.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/util/SqlValidation.java
@@ -240,13 +240,9 @@ public class SqlValidation {
         new AbstractMap.SimpleEntry<>("eventType", varChar)));
       RelDataType parentEventGbifId = tdf.createArrayType(keyValuePair, -1);
 
-      // Geological range structure: STRUCT<gt: DOUBLE,lte: DOUBLE>
-      RelDataType geologicalRange = tdf.createStructType(StructKind.PEEK_FIELDS_NO_EXPAND,
-        Arrays.asList(doubleType, doubleType),
-        Arrays.asList("gt", "lte"));
-
       //  Map definition - needed for multiple classifications
       RelDataType structMap = tdf.createMapType(varChar, varCharArray);
+      RelDataType structMapOfMap = tdf.createMapType(varChar, tdf.createMapType(varChar, varChar));
 
       OccurrenceHDFSTableDefinition.definition().stream().forEach(
         field -> {
@@ -267,6 +263,10 @@ public class SqlValidation {
 
             case HiveDataTypes.TYPE_MAP_STRUCT:
               builder.add(field.getColumnName(), structMap);
+              break;
+
+            case HiveDataTypes.TYPE_MAP_OF_MAP_STRUCT:
+              builder.add(field.getColumnName(), structMapOfMap);
               break;
 
             case HiveDataTypes.TYPE_ARRAY_PARENT_STRUCT:

--- a/occurrence-download/src/test/java/org/gbif/occurrence/download/file/OccurrenceMapReaderTest.java
+++ b/occurrence-download/src/test/java/org/gbif/occurrence/download/file/OccurrenceMapReaderTest.java
@@ -13,6 +13,8 @@
  */
 package org.gbif.occurrence.download.file;
 
+import org.gbif.api.model.Constants;
+import org.gbif.api.model.common.Classification;
 import org.gbif.api.model.common.MediaObject;
 import org.gbif.api.model.occurrence.Occurrence;
 import org.gbif.api.vocabulary.BasisOfRecord;
@@ -69,6 +71,26 @@ public class OccurrenceMapReaderTest {
     occurrence.setReferences(reference);
     occurrence.setLicense(License.CC_BY_4_0);
 
+    Classification classification = Classification.builder()
+      .usage(org.gbif.api.v2.Usage.builder()
+        .key("2440897")
+        .name(scientificName).build())
+      .acceptedUsage(org.gbif.api.v2.Usage.builder()
+        .key("2440897")
+        .name(scientificName).build())
+      .classification(List.of(
+        org.gbif.api.v2.RankedName.builder().name("Animalia").rank("KINGDOM").key("1").build(),
+        org.gbif.api.v2.RankedName.builder().name("Chordata").rank("PHYLUM").key("1").build(),
+        org.gbif.api.v2.RankedName.builder().name("Mammalia").rank("CLASS").key("1").build(),
+        org.gbif.api.v2.RankedName.builder().name("Perissodactyla").rank("ORDER").key("1").build(),
+        org.gbif.api.v2.RankedName.builder().name("Tapiridae").rank("FAMILY").key("1").build(),
+        org.gbif.api.v2.RankedName.builder().name("Tapirus").rank("GENUS").key("1").build(),
+        org.gbif.api.v2.RankedName.builder().name("bairdii").rank("SPECIES").key("1").build()
+    )).build();
+
+    occurrence.setClassifications(
+      Map.of(Constants.NUB_DATASET_KEY.toString(), classification));
+
     //Varbatim fields not populated by Java fields must be copied into the result
     occurrence.setVerbatimField(DwcTerm.institutionCode, "INST");
 
@@ -95,7 +117,7 @@ public class OccurrenceMapReaderTest {
     occurrence.setIssues(issues);
 
 
-    Map<String,String> occurrenceMap = OccurrenceMapReader.buildInterpretedOccurrenceMap(occurrence);
+    Map<String,String> occurrenceMap = OccurrenceMapReader.buildInterpretedOccurrenceMap(occurrence, Constants.NUB_DATASET_KEY.toString());
 
     assertEquals(Country.COSTA_RICA.getIso2LetterCode(), occurrenceMap.get(DwcTerm.countryCode.simpleName()));
     assertEquals(Country.TRINIDAD_TOBAGO.getIso2LetterCode(), occurrenceMap.get(GbifTerm.publishingCountry.simpleName()));

--- a/occurrence-download/src/test/java/org/gbif/occurrence/download/hive/ExtensionsQueryTest.java
+++ b/occurrence-download/src/test/java/org/gbif/occurrence/download/hive/ExtensionsQueryTest.java
@@ -13,6 +13,7 @@
  */
 package org.gbif.occurrence.download.hive;
 
+import org.gbif.api.model.Constants;
 import org.gbif.api.model.occurrence.Download;
 import org.gbif.api.model.occurrence.DownloadFormat;
 import org.gbif.api.model.occurrence.DownloadType;
@@ -44,7 +45,9 @@ public class ExtensionsQueryTest {
       DownloadType.OCCURRENCE,
       null,
       null,
-      Extension.availableExtensions());
+      Extension.availableExtensions(),
+      Constants.NUB_DATASET_KEY.toString()
+    );
 
     Download download = new Download();
     download.setKey("extension-test");

--- a/occurrence-download/src/test/java/org/gbif/occurrence/download/hive/GenerateHQLTest.java
+++ b/occurrence-download/src/test/java/org/gbif/occurrence/download/hive/GenerateHQLTest.java
@@ -14,8 +14,7 @@
 package org.gbif.occurrence.download.hive;
 
 
-import org.gbif.occurrence.download.sql.SqlQueryUtils;
-
+import org.gbif.api.model.Constants;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -24,22 +23,22 @@ public class GenerateHQLTest {
 
   @Test
   public void simpleCsvTest() throws Exception {
-    String simpleCsvDownloadQuery = GenerateHQL.simpleCsvQueryHQL();
+    String simpleCsvDownloadQuery = GenerateHQL.simpleCsvQueryHQL(Constants.NUB_DATASET_KEY.toString());
     System.out.println(simpleCsvDownloadQuery);
   }
 
   @Test
   public void dwcaTest() throws Exception {
-    String dwcaDownloadQuery = SqlQueryUtils.queryTemplateToString(GenerateHQL::generateDwcaQueryHQL);
+    String dwcaDownloadQuery = GenerateHQL.generateDwcaQueryHQL(Constants.NUB_DATASET_KEY.toString());
     System.out.println(dwcaDownloadQuery);
   }
 
   @Test
   public void simpleParquetTest() throws Exception {
-    String simpleParquetDownloadQuery = GenerateHQL.simpleParquetQueryHQL();
+    String simpleParquetDownloadQuery = GenerateHQL.simpleParquetQueryHQL(Constants.NUB_DATASET_KEY.toString());
     System.out.println(simpleParquetDownloadQuery);
 
     assertTrue("Column names should be lower-case", simpleParquetDownloadQuery.contains("`datasetkey` STRING"));
-    assertTrue("Verbatim column names should be lower-case", simpleParquetDownloadQuery.contains("`verbatimScientificName` STRING"));
+    assertTrue("Verbatim column names should be lower-case", simpleParquetDownloadQuery.contains("`verbatimscientificname` STRING"));
   }
 }

--- a/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/SearchHitOccurrenceConverter.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/SearchHitOccurrenceConverter.java
@@ -13,6 +13,7 @@
  */
 package org.gbif.occurrence.search.es;
 
+import org.gbif.api.model.Constants;
 import org.gbif.api.model.common.Classification;
 import org.gbif.api.model.common.Identifier;
 import org.gbif.api.model.common.MediaObject;
@@ -72,15 +73,12 @@ import com.google.common.collect.Maps;
 public class SearchHitOccurrenceConverter extends SearchHitConverter<Occurrence> {
 
   private final boolean excludeInterpretedFromVerbatim;
-  private final String defaultChecklistKey;
 
   public SearchHitOccurrenceConverter(
     OccurrenceBaseEsFieldMapper occurrenceBaseEsFieldMapper,
-    boolean excludeInterpretedFromVerbatim,
-    String defaultChecklistKey) {
+    boolean excludeInterpretedFromVerbatim) {
     super(occurrenceBaseEsFieldMapper);
     this.excludeInterpretedFromVerbatim = excludeInterpretedFromVerbatim;
-    this.defaultChecklistKey = defaultChecklistKey;
   }
 
   @Override
@@ -395,33 +393,33 @@ public class SearchHitOccurrenceConverter extends SearchHitConverter<Occurrence>
   @Deprecated
   private void setTaxonFields(SearchHit hit, Occurrence occ) {
 
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.kingdomKey), defaultChecklistKey).ifPresent(occ::setKingdomKey);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.kingdom), defaultChecklistKey).ifPresent(occ::setKingdom);
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.phylumKey), defaultChecklistKey).ifPresent(occ::setPhylumKey);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.phylum), defaultChecklistKey).ifPresent(occ::setPhylum);
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.classKey), defaultChecklistKey).ifPresent(occ::setClassKey);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.class_), defaultChecklistKey).ifPresent(occ::setClazz);
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.orderKey), defaultChecklistKey).ifPresent(occ::setOrderKey);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.order), defaultChecklistKey).ifPresent(occ::setOrder);
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.familyKey), defaultChecklistKey).ifPresent(occ::setFamilyKey);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.family), defaultChecklistKey).ifPresent(occ::setFamily);
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.genusKey), defaultChecklistKey).ifPresent(occ::setGenusKey);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.genus), defaultChecklistKey).ifPresent(occ::setGenus);
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.subgenusKey), defaultChecklistKey).ifPresent(occ::setSubgenusKey);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.subgenus), defaultChecklistKey).ifPresent(occ::setSubgenus);
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.speciesKey), defaultChecklistKey).ifPresent(occ::setSpeciesKey);
-    getChecklistStringValue(hit, getChecklistField(GbifTerm.species), defaultChecklistKey).ifPresent(occ::setSpecies);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.scientificName), defaultChecklistKey).ifPresent(occ::setScientificName);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.scientificNameAuthorship), defaultChecklistKey).ifPresent(occ::setScientificNameAuthorship);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.specificEpithet), defaultChecklistKey).ifPresent(occ::setSpecificEpithet);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.infraspecificEpithet), defaultChecklistKey).ifPresent(occ::setInfraspecificEpithet);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.genericName), defaultChecklistKey).ifPresent(occ::setGenericName);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.taxonRank), defaultChecklistKey).ifPresent(v -> occ.setTaxonRank(Rank.valueOf(v)));
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.taxonKey), defaultChecklistKey).ifPresent(occ::setTaxonKey);
-    getChecklistIntValue(hit, getChecklistField(GbifTerm.acceptedTaxonKey), defaultChecklistKey).ifPresent(occ::setAcceptedTaxonKey);
-    getChecklistStringValue(hit, getChecklistField(GbifTerm.acceptedScientificName), defaultChecklistKey).ifPresent(occ::setAcceptedScientificName);
-    getChecklistStringValue(hit, getChecklistField(DwcTerm.taxonomicStatus), defaultChecklistKey).ifPresent(v -> occ.setTaxonomicStatus(TaxonomicStatus.valueOf(v)));
-    getChecklistStringValue(hit, getChecklistField(IucnTerm.iucnRedListCategory), defaultChecklistKey).ifPresent(occ::setIucnRedListCategory);
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.kingdomKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setKingdomKey);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.kingdom), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setKingdom);
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.phylumKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setPhylumKey);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.phylum), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setPhylum);
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.classKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setClassKey);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.class_), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setClazz);
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.orderKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setOrderKey);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.order), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setOrder);
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.familyKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setFamilyKey);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.family), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setFamily);
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.genusKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setGenusKey);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.genus), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setGenus);
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.subgenusKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setSubgenusKey);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.subgenus), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setSubgenus);
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.speciesKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setSpeciesKey);
+    getChecklistStringValue(hit, getChecklistField(GbifTerm.species), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setSpecies);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.scientificName), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setScientificName);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.scientificNameAuthorship), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setScientificNameAuthorship);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.specificEpithet), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setSpecificEpithet);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.infraspecificEpithet), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setInfraspecificEpithet);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.genericName), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setGenericName);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.taxonRank), Constants.NUB_DATASET_KEY.toString()).ifPresent(v -> occ.setTaxonRank(Rank.valueOf(v)));
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.taxonKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setTaxonKey);
+    getChecklistIntValue(hit, getChecklistField(GbifTerm.acceptedTaxonKey), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setAcceptedTaxonKey);
+    getChecklistStringValue(hit, getChecklistField(GbifTerm.acceptedScientificName), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setAcceptedScientificName);
+    getChecklistStringValue(hit, getChecklistField(DwcTerm.taxonomicStatus), Constants.NUB_DATASET_KEY.toString()).ifPresent(v -> occ.setTaxonomicStatus(TaxonomicStatus.valueOf(v)));
+    getChecklistStringValue(hit, getChecklistField(IucnTerm.iucnRedListCategory), Constants.NUB_DATASET_KEY.toString()).ifPresent(occ::setIucnRedListCategory);
   }
 
   private ChecklistEsField getChecklistField(Term term) {

--- a/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/DownloadTerms.java
+++ b/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/DownloadTerms.java
@@ -115,6 +115,7 @@ public class DownloadTerms {
     Pair.of(Group.INTERPRETED, GbifTerm.gbifID),
     Pair.of(Group.INTERPRETED, GbifTerm.datasetKey),
     Pair.of(Group.INTERPRETED, DwcTerm.occurrenceID),
+
     Pair.of(Group.INTERPRETED, DwcTerm.kingdom),
     Pair.of(Group.INTERPRETED, DwcTerm.phylum),
     Pair.of(Group.INTERPRETED, DwcTerm.class_),
@@ -125,6 +126,7 @@ public class DownloadTerms {
     Pair.of(Group.INTERPRETED, DwcTerm.infraspecificEpithet),
     Pair.of(Group.INTERPRETED, DwcTerm.taxonRank),
     Pair.of(Group.INTERPRETED, DwcTerm.scientificName),
+
     Pair.of(Group.VERBATIM, DwcTerm.scientificName),
     Pair.of(Group.VERBATIM, DwcTerm.scientificNameAuthorship),
     Pair.of(Group.INTERPRETED, DwcTerm.countryCode),
@@ -264,21 +266,6 @@ public class DownloadTerms {
     GbifInternalTerm.eventDateGte,
     GbifInternalTerm.eventDateLte
   );
-
-  /*
-   * The terms available for searching/selecting for occurrence SQL downloads.
-   */
-  public static final Set<Term> DOWNLOAD_SQL_VERBATIM_TERMS = DOWNLOAD_VERBATIM_TERMS;
-
-  /*
-   * The terms available for searching/selecting for occurrence SQL downloads.
-   */
-  public static final Set<Term> DOWNLOAD_SQL_TERMS = new ImmutableSet.Builder<Term>()
-    .addAll(DOWNLOAD_INTERPRETED_TERMS)
-    .addAll(DOWNLOAD_MULTIMEDIA_TERMS)
-    .addAll(INTERNAL_DOWNLOAD_TERMS)
-    .addAll(INTERNAL_SEARCH_TERMS)
-    .add(GbifTerm.verbatimScientificName).build();
 
   public static String simpleName(Pair<Group, Term> termPair) {
     Term term = termPair.getRight();

--- a/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/HiveColumns.java
+++ b/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/HiveColumns.java
@@ -39,7 +39,6 @@ public final class HiveColumns {
   private static final ImmutableSet<String> RESERVED_WORDS = ImmutableSet.of("date", "order", "format", "group");
   // reserved ISO SQL words, see https://en.wikipedia.org/wiki/List_of_SQL_reserved_words for more.
   private static final ImmutableSet<String> ISO_RESERVED_WORDS = ImmutableSet.of("date", "order", "format", "group", "year", "month", "day", "language", "references", "member");
-  private static final Pattern START_WITH_DIGIT = Pattern.compile("(\\d.*)");
   private static final Pattern START_WITH_DIGIT_OR_UNDERSCORE = Pattern.compile("(\\d.*)|(_.*)");
 
   public static String getVerbatimColPrefix() {

--- a/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/HiveDataTypes.java
+++ b/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/HiveDataTypes.java
@@ -50,6 +50,7 @@ public final class HiveDataTypes {
   public static final String TYPE_VOCABULARY_STRUCT = "STRUCT<concept: STRING,lineage: ARRAY<STRING>>";
   public static final String TYPE_VOCABULARY_ARRAY_STRUCT = "STRUCT<concepts: ARRAY<STRING>,lineage: ARRAY<STRING>>";
   public static final String TYPE_MAP_STRUCT = "MAP<STRING, ARRAY<STRING>>";
+  public static final String TYPE_MAP_OF_MAP_STRUCT = "MAP<STRING, MAP<STRING, STRING>>";
   public static final String TYPE_ARRAY_PARENT_STRUCT = "ARRAY<STRUCT<id: STRING,eventType: STRING>>";
   public static final String GEOLOGICAL_RANGE_STRUCT = "STRUCT<gt: DOUBLE,lte: DOUBLE>";
   public static final String TYPE_TIMESTAMP = "TIMESTAMP";
@@ -163,6 +164,8 @@ public final class HiveDataTypes {
       }
     } else if (term.equals(GbifInternalTerm.classifications)) {
       return TYPE_MAP_STRUCT;
+    } else if (term.equals(GbifInternalTerm.classificationDetails)) {
+      return TYPE_MAP_OF_MAP_STRUCT;
     } else {
       return TYPED_TERMS.getOrDefault(term, TYPE_STRING); // interpreted term with a registered type
     }

--- a/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/OccurrenceAvroHdfsTableDefinition.java
+++ b/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/OccurrenceAvroHdfsTableDefinition.java
@@ -62,6 +62,9 @@ public class OccurrenceAvroHdfsTableDefinition {
       case HiveDataTypes.TYPE_MAP_STRUCT:
         builder.name(initializableField.getColumnName()).type().nullable().map().values().array().items().stringType().noDefault();
         break;
+      case HiveDataTypes.TYPE_MAP_OF_MAP_STRUCT:
+        builder.name(initializableField.getColumnName()).type().nullable().map().values().map().values().stringType().noDefault();
+        break;
       case HiveDataTypes.TYPE_VOCABULARY_STRUCT:
         builder.name(initializableField.getColumnName()).type().nullable().record(getTypeRecordName(initializableField))
           .fields()

--- a/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/OccurrenceHDFSTableDefinition.java
+++ b/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/OccurrenceHDFSTableDefinition.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -35,7 +36,7 @@ import static org.gbif.occurrence.download.hive.HiveColumns.getVerbatimColPrefix
 /**
  * This provides the definition required to construct the occurrence HDFS table, for use as a Hive table.
  * The table is populated by a query which scans the Avro files, but along the way converts some fields to
- * e.g. Hive arrays which requires some UDF voodoo captured here.
+ * e.g., Hive arrays which require some UDF voodoo captured here.
  * <p/>
  * Note to developers: It is not easy to find a perfectly clean solution to this work.  Here we try and favour long
  * term code management over all else.  For that reason, Functional programming idioms are not used even though they
@@ -48,6 +49,15 @@ import static org.gbif.occurrence.download.hive.HiveColumns.getVerbatimColPrefix
  */
 @UtilityClass
 public class OccurrenceHDFSTableDefinition {
+
+  public static void main(String[] args) {
+    System.out.println(
+      "CREATE TABLE IF NOT EXISTS occurrence (\n"
+        + OccurrenceHDFSTableDefinition.definition().stream()
+        .map(field -> field.getHiveField() + " " + field.getHiveDataType())
+        .collect(Collectors.joining(", \n"))
+        + ") STORED AS PARQUET TBLPROPERTIES (\"parquet.compression\"=\"SNAPPY\")");
+  }
 
   private static final Set<Term> ARRAYS_FROM_VERBATIM_VALUES =
       ImmutableSet.of(
@@ -93,6 +103,7 @@ public class OccurrenceHDFSTableDefinition {
                                       .put(DwcTerm.eventType, columnFor(DwcTerm.eventType))
                                       .put(IucnTerm.iucnRedListCategory, columnFor(IucnTerm.iucnRedListCategory))
                                       .put(GbifInternalTerm.classifications, columnFor(GbifInternalTerm.classifications))
+                                      .put(GbifInternalTerm.classificationDetails, columnFor(GbifInternalTerm.classificationDetails))
                                       .put(GbifTerm.checklistKey, columnFor(GbifTerm.checklistKey))
                                       .build();
 

--- a/occurrence-hdfs-table/src/main/resources/table/dna-derived-data-table.avsc
+++ b/occurrence-hdfs-table/src/main/resources/table/dna-derived-data-table.avsc
@@ -15,882 +15,922 @@
   }, {
     "name" : "sampname",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0001107",
+    "doc" : "https://w3id.org/mixs/0001107",
     "default" : null
   }, {
     "name" : "v_sampname",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0001107",
+    "doc" : "https://w3id.org/mixs/0001107",
+    "default" : null
+  }, {
+    "name" : "occurrenceid",
+    "type" : [ "null", "string" ],
+    "doc" : "http://rs.tdwg.org/dwc/terms/occurrenceID",
+    "default" : null
+  }, {
+    "name" : "v_occurrenceid",
+    "type" : [ "null", "string" ],
+    "doc" : "http://rs.tdwg.org/dwc/terms/occurrenceID",
     "default" : null
   }, {
     "name" : "projectname",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000092",
+    "doc" : "https://w3id.org/mixs/0000092",
     "default" : null
   }, {
     "name" : "v_projectname",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000092",
+    "doc" : "https://w3id.org/mixs/0000092",
     "default" : null
   }, {
     "name" : "experimentalfactor",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000008",
+    "doc" : "https://w3id.org/mixs/0000008",
     "default" : null
   }, {
     "name" : "v_experimentalfactor",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000008",
+    "doc" : "https://w3id.org/mixs/0000008",
+    "default" : null
+  }, {
+    "name" : "samptaxonid",
+    "type" : [ "null", "string" ],
+    "doc" : "https://w3id.org/mixs/0001320",
+    "default" : null
+  }, {
+    "name" : "v_samptaxonid",
+    "type" : [ "null", "string" ],
+    "doc" : "https://w3id.org/mixs/0001320",
+    "default" : null
+  }, {
+    "name" : "negconttype",
+    "type" : [ "null", "string" ],
+    "doc" : "https://w3id.org/mixs/0001321",
+    "default" : null
+  }, {
+    "name" : "v_negconttype",
+    "type" : [ "null", "string" ],
+    "doc" : "https://w3id.org/mixs/0001321",
+    "default" : null
+  }, {
+    "name" : "posconttype",
+    "type" : [ "null", "string" ],
+    "doc" : "https://w3id.org/mixs/0001322",
+    "default" : null
+  }, {
+    "name" : "v_posconttype",
+    "type" : [ "null", "string" ],
+    "doc" : "https://w3id.org/mixs/0001322",
     "default" : null
   }, {
     "name" : "envbroadscale",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000012",
+    "doc" : "https://w3id.org/mixs/0000012",
     "default" : null
   }, {
     "name" : "v_envbroadscale",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000012",
+    "doc" : "https://w3id.org/mixs/0000012",
     "default" : null
   }, {
     "name" : "envlocalscale",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000013",
+    "doc" : "https://w3id.org/mixs/0000013",
     "default" : null
   }, {
     "name" : "v_envlocalscale",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000013",
+    "doc" : "https://w3id.org/mixs/0000013",
     "default" : null
   }, {
     "name" : "envmedium",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000014",
+    "doc" : "https://w3id.org/mixs/0000014",
     "default" : null
   }, {
     "name" : "v_envmedium",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000014",
+    "doc" : "https://w3id.org/mixs/0000014",
     "default" : null
   }, {
     "name" : "subspecfgenlin",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000020",
+    "doc" : "https://w3id.org/mixs/0000020",
     "default" : null
   }, {
     "name" : "v_subspecfgenlin",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000020",
+    "doc" : "https://w3id.org/mixs/0000020",
     "default" : null
   }, {
     "name" : "ploidy",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000021",
+    "doc" : "https://w3id.org/mixs/0000021",
     "default" : null
   }, {
     "name" : "v_ploidy",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000021",
+    "doc" : "https://w3id.org/mixs/0000021",
     "default" : null
   }, {
     "name" : "numreplicons",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000022",
+    "doc" : "https://w3id.org/mixs/0000022",
     "default" : null
   }, {
     "name" : "v_numreplicons",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000022",
+    "doc" : "https://w3id.org/mixs/0000022",
     "default" : null
   }, {
     "name" : "extrachromelements",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000023",
+    "doc" : "https://w3id.org/mixs/0000023",
     "default" : null
   }, {
     "name" : "v_extrachromelements",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000023",
+    "doc" : "https://w3id.org/mixs/0000023",
     "default" : null
   }, {
     "name" : "estimatedsize",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000024",
+    "doc" : "https://w3id.org/mixs/0000024",
     "default" : null
   }, {
     "name" : "v_estimatedsize",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000024",
+    "doc" : "https://w3id.org/mixs/0000024",
     "default" : null
   }, {
     "name" : "refbiomaterial",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000025",
+    "doc" : "https://w3id.org/mixs/0000025",
     "default" : null
   }, {
     "name" : "v_refbiomaterial",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000025",
+    "doc" : "https://w3id.org/mixs/0000025",
     "default" : null
   }, {
     "name" : "sourcematid",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000026",
+    "doc" : "https://w3id.org/mixs/0000026",
     "default" : null
   }, {
     "name" : "v_sourcematid",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000026",
+    "doc" : "https://w3id.org/mixs/0000026",
     "default" : null
   }, {
     "name" : "pathogenicity",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000027",
+    "doc" : "https://w3id.org/mixs/0000027",
     "default" : null
   }, {
     "name" : "v_pathogenicity",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000027",
+    "doc" : "https://w3id.org/mixs/0000027",
     "default" : null
   }, {
     "name" : "bioticrelationship",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000028",
+    "doc" : "https://w3id.org/mixs/0000028",
     "default" : null
   }, {
     "name" : "v_bioticrelationship",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000028",
+    "doc" : "https://w3id.org/mixs/0000028",
     "default" : null
   }, {
     "name" : "specifichost",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000029",
+    "doc" : "https://w3id.org/mixs/0000029",
     "default" : null
   }, {
     "name" : "v_specifichost",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000029",
+    "doc" : "https://w3id.org/mixs/0000029",
     "default" : null
   }, {
     "name" : "hostspecrange",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000030",
+    "doc" : "https://w3id.org/mixs/0000030",
     "default" : null
   }, {
     "name" : "v_hostspecrange",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000030",
+    "doc" : "https://w3id.org/mixs/0000030",
     "default" : null
   }, {
     "name" : "hostdiseasestat",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000031",
+    "doc" : "https://w3id.org/mixs/0000031",
     "default" : null
   }, {
     "name" : "v_hostdiseasestat",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000031",
+    "doc" : "https://w3id.org/mixs/0000031",
     "default" : null
   }, {
     "name" : "trophiclevel",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000032",
+    "doc" : "https://w3id.org/mixs/0000032",
     "default" : null
   }, {
     "name" : "v_trophiclevel",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000032",
+    "doc" : "https://w3id.org/mixs/0000032",
     "default" : null
   }, {
     "name" : "propagation",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000033",
+    "doc" : "https://w3id.org/mixs/0000033",
     "default" : null
   }, {
     "name" : "v_propagation",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000033",
+    "doc" : "https://w3id.org/mixs/0000033",
     "default" : null
   }, {
     "name" : "encodedtraits",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000034",
+    "doc" : "https://w3id.org/mixs/0000034",
     "default" : null
   }, {
     "name" : "v_encodedtraits",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000034",
+    "doc" : "https://w3id.org/mixs/0000034",
     "default" : null
   }, {
     "name" : "reltooxygen",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000015",
+    "doc" : "https://w3id.org/mixs/0000015",
     "default" : null
   }, {
     "name" : "v_reltooxygen",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000015",
+    "doc" : "https://w3id.org/mixs/0000015",
     "default" : null
   }, {
     "name" : "isolgrowthcondt",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000003",
+    "doc" : "https://w3id.org/mixs/0000003",
     "default" : null
   }, {
     "name" : "v_isolgrowthcondt",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000003",
+    "doc" : "https://w3id.org/mixs/0000003",
     "default" : null
   }, {
     "name" : "sampcollecdevice",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000002",
+    "doc" : "https://w3id.org/mixs/0000002",
     "default" : null
   }, {
     "name" : "v_sampcollecdevice",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000002",
+    "doc" : "https://w3id.org/mixs/0000002",
     "default" : null
   }, {
     "name" : "sampcollecmethod",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0001225",
+    "doc" : "https://w3id.org/mixs/0001225",
     "default" : null
   }, {
     "name" : "v_sampcollecmethod",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0001225",
+    "doc" : "https://w3id.org/mixs/0001225",
     "default" : null
   }, {
     "name" : "sampmatprocess",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000016",
+    "doc" : "https://w3id.org/mixs/0000016",
     "default" : null
   }, {
     "name" : "v_sampmatprocess",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000016",
+    "doc" : "https://w3id.org/mixs/0000016",
     "default" : null
   }, {
     "name" : "sizefrac",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000017",
+    "doc" : "https://w3id.org/mixs/0000017",
     "default" : null
   }, {
     "name" : "v_sizefrac",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000017",
+    "doc" : "https://w3id.org/mixs/0000017",
     "default" : null
   }, {
     "name" : "sampsize",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000001",
+    "doc" : "https://w3id.org/mixs/0000001",
     "default" : null
   }, {
     "name" : "v_sampsize",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000001",
+    "doc" : "https://w3id.org/mixs/0000001",
     "default" : null
   }, {
     "name" : "sampvolwednaext",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000111",
+    "doc" : "https://w3id.org/mixs/0000111",
     "default" : null
   }, {
     "name" : "v_sampvolwednaext",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000111",
+    "doc" : "https://w3id.org/mixs/0000111",
     "default" : null
   }, {
     "name" : "sourceuvig",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000035",
+    "doc" : "https://w3id.org/mixs/0000035",
     "default" : null
   }, {
     "name" : "v_sourceuvig",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000035",
+    "doc" : "https://w3id.org/mixs/0000035",
     "default" : null
   }, {
     "name" : "virusenrichappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000036",
+    "doc" : "https://w3id.org/mixs/0000036",
     "default" : null
   }, {
     "name" : "v_virusenrichappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000036",
+    "doc" : "https://w3id.org/mixs/0000036",
     "default" : null
   }, {
     "name" : "nuclacidext",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000037",
+    "doc" : "https://w3id.org/mixs/0000037",
     "default" : null
   }, {
     "name" : "v_nuclacidext",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000037",
+    "doc" : "https://w3id.org/mixs/0000037",
     "default" : null
   }, {
     "name" : "nuclacidamp",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000038",
+    "doc" : "https://w3id.org/mixs/0000038",
     "default" : null
   }, {
     "name" : "v_nuclacidamp",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000038",
+    "doc" : "https://w3id.org/mixs/0000038",
     "default" : null
   }, {
     "name" : "libsize",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000039",
+    "doc" : "https://w3id.org/mixs/0000039",
     "default" : null
   }, {
     "name" : "v_libsize",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000039",
+    "doc" : "https://w3id.org/mixs/0000039",
     "default" : null
   }, {
     "name" : "libreadsseqd",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000040",
+    "doc" : "https://w3id.org/mixs/0000040",
     "default" : null
   }, {
     "name" : "v_libreadsseqd",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000040",
+    "doc" : "https://w3id.org/mixs/0000040",
     "default" : null
   }, {
     "name" : "liblayout",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000041",
+    "doc" : "https://w3id.org/mixs/0000041",
     "default" : null
   }, {
     "name" : "v_liblayout",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000041",
+    "doc" : "https://w3id.org/mixs/0000041",
     "default" : null
   }, {
     "name" : "libvector",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000042",
+    "doc" : "https://w3id.org/mixs/0000042",
     "default" : null
   }, {
     "name" : "v_libvector",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000042",
+    "doc" : "https://w3id.org/mixs/0000042",
     "default" : null
   }, {
     "name" : "libscreen",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000043",
+    "doc" : "https://w3id.org/mixs/0000043",
     "default" : null
   }, {
     "name" : "v_libscreen",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000043",
+    "doc" : "https://w3id.org/mixs/0000043",
     "default" : null
   }, {
     "name" : "targetgene",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000044",
+    "doc" : "https://w3id.org/mixs/0000044",
     "default" : null
   }, {
     "name" : "v_targetgene",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000044",
+    "doc" : "https://w3id.org/mixs/0000044",
     "default" : null
   }, {
     "name" : "targetsubfragment",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000045",
+    "doc" : "https://w3id.org/mixs/0000045",
     "default" : null
   }, {
     "name" : "v_targetsubfragment",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000045",
+    "doc" : "https://w3id.org/mixs/0000045",
     "default" : null
   }, {
     "name" : "pcrprimers",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000046",
+    "doc" : "https://w3id.org/mixs/0000046",
     "default" : null
   }, {
     "name" : "v_pcrprimers",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000046",
+    "doc" : "https://w3id.org/mixs/0000046",
     "default" : null
   }, {
     "name" : "mid",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000047",
+    "doc" : "https://w3id.org/mixs/0000047",
     "default" : null
   }, {
     "name" : "v_mid",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000047",
+    "doc" : "https://w3id.org/mixs/0000047",
     "default" : null
   }, {
     "name" : "adapters",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000048",
+    "doc" : "https://w3id.org/mixs/0000048",
     "default" : null
   }, {
     "name" : "v_adapters",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000048",
+    "doc" : "https://w3id.org/mixs/0000048",
     "default" : null
   }, {
     "name" : "pcrcond",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000049",
+    "doc" : "https://w3id.org/mixs/0000049",
     "default" : null
   }, {
     "name" : "v_pcrcond",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000049",
+    "doc" : "https://w3id.org/mixs/0000049",
     "default" : null
   }, {
     "name" : "seqmeth",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000050",
+    "doc" : "https://w3id.org/mixs/0000050",
     "default" : null
   }, {
     "name" : "v_seqmeth",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000050",
+    "doc" : "https://w3id.org/mixs/0000050",
     "default" : null
   }, {
     "name" : "seqqualitycheck",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000051",
+    "doc" : "https://w3id.org/mixs/0000051",
     "default" : null
   }, {
     "name" : "v_seqqualitycheck",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000051",
+    "doc" : "https://w3id.org/mixs/0000051",
     "default" : null
   }, {
     "name" : "chimeracheck",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000052",
+    "doc" : "https://w3id.org/mixs/0000052",
     "default" : null
   }, {
     "name" : "v_chimeracheck",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000052",
+    "doc" : "https://w3id.org/mixs/0000052",
     "default" : null
   }, {
     "name" : "taxident",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000053",
+    "doc" : "https://w3id.org/mixs/0000053",
     "default" : null
   }, {
     "name" : "v_taxident",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000053",
+    "doc" : "https://w3id.org/mixs/0000053",
     "default" : null
   }, {
     "name" : "assemblyqual",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000056",
+    "doc" : "https://w3id.org/mixs/0000056",
     "default" : null
   }, {
     "name" : "v_assemblyqual",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000056",
+    "doc" : "https://w3id.org/mixs/0000056",
     "default" : null
   }, {
     "name" : "assemblyname",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000057",
+    "doc" : "https://w3id.org/mixs/0000057",
     "default" : null
   }, {
     "name" : "v_assemblyname",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000057",
+    "doc" : "https://w3id.org/mixs/0000057",
     "default" : null
   }, {
     "name" : "assemblysoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000058",
+    "doc" : "https://w3id.org/mixs/0000058",
     "default" : null
   }, {
     "name" : "v_assemblysoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000058",
+    "doc" : "https://w3id.org/mixs/0000058",
     "default" : null
   }, {
     "name" : "annot",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000059",
+    "doc" : "https://w3id.org/mixs/0000059",
     "default" : null
   }, {
     "name" : "v_annot",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000059",
+    "doc" : "https://w3id.org/mixs/0000059",
     "default" : null
   }, {
     "name" : "numbercontig",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000060",
+    "doc" : "https://w3id.org/mixs/0000060",
     "default" : null
   }, {
     "name" : "v_numbercontig",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000060",
+    "doc" : "https://w3id.org/mixs/0000060",
     "default" : null
   }, {
     "name" : "featpred",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000061",
+    "doc" : "https://w3id.org/mixs/0000061",
     "default" : null
   }, {
     "name" : "v_featpred",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000061",
+    "doc" : "https://w3id.org/mixs/0000061",
     "default" : null
   }, {
     "name" : "refdb",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000062",
+    "doc" : "https://w3id.org/mixs/0000062",
     "default" : null
   }, {
     "name" : "v_refdb",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000062",
+    "doc" : "https://w3id.org/mixs/0000062",
     "default" : null
   }, {
     "name" : "simsearchmeth",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000063",
+    "doc" : "https://w3id.org/mixs/0000063",
     "default" : null
   }, {
     "name" : "v_simsearchmeth",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000063",
+    "doc" : "https://w3id.org/mixs/0000063",
     "default" : null
   }, {
     "name" : "taxclass",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000064",
+    "doc" : "https://w3id.org/mixs/0000064",
     "default" : null
   }, {
     "name" : "v_taxclass",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000064",
+    "doc" : "https://w3id.org/mixs/0000064",
     "default" : null
   }, {
     "name" : "_16srecover",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000065",
+    "doc" : "https://w3id.org/mixs/0000065",
     "default" : null
   }, {
     "name" : "v_16srecover",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000065",
+    "doc" : "https://w3id.org/mixs/0000065",
     "default" : null
   }, {
     "name" : "_16srecoversoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000066",
+    "doc" : "https://w3id.org/mixs/0000066",
     "default" : null
   }, {
     "name" : "v_16srecoversoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000066",
+    "doc" : "https://w3id.org/mixs/0000066",
     "default" : null
   }, {
     "name" : "trnas",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000067",
+    "doc" : "https://w3id.org/mixs/0000067",
     "default" : null
   }, {
     "name" : "v_trnas",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000067",
+    "doc" : "https://w3id.org/mixs/0000067",
     "default" : null
   }, {
     "name" : "trnaextsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000068",
+    "doc" : "https://w3id.org/mixs/0000068",
     "default" : null
   }, {
     "name" : "v_trnaextsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000068",
+    "doc" : "https://w3id.org/mixs/0000068",
     "default" : null
   }, {
     "name" : "complscore",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000069",
+    "doc" : "https://w3id.org/mixs/0000069",
     "default" : null
   }, {
     "name" : "v_complscore",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000069",
+    "doc" : "https://w3id.org/mixs/0000069",
     "default" : null
   }, {
     "name" : "complsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000070",
+    "doc" : "https://w3id.org/mixs/0000070",
     "default" : null
   }, {
     "name" : "v_complsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000070",
+    "doc" : "https://w3id.org/mixs/0000070",
     "default" : null
   }, {
     "name" : "complappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000071",
+    "doc" : "https://w3id.org/mixs/0000071",
     "default" : null
   }, {
     "name" : "v_complappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000071",
+    "doc" : "https://w3id.org/mixs/0000071",
     "default" : null
   }, {
     "name" : "contamscore",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000072",
+    "doc" : "https://w3id.org/mixs/0000072",
     "default" : null
   }, {
     "name" : "v_contamscore",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000072",
+    "doc" : "https://w3id.org/mixs/0000072",
     "default" : null
   }, {
     "name" : "contamscreeninput",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000005",
+    "doc" : "https://w3id.org/mixs/0000005",
     "default" : null
   }, {
     "name" : "v_contamscreeninput",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000005",
+    "doc" : "https://w3id.org/mixs/0000005",
     "default" : null
   }, {
     "name" : "contamscreenparam",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000073",
+    "doc" : "https://w3id.org/mixs/0000073",
     "default" : null
   }, {
     "name" : "v_contamscreenparam",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000073",
+    "doc" : "https://w3id.org/mixs/0000073",
     "default" : null
   }, {
     "name" : "decontamsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000074",
+    "doc" : "https://w3id.org/mixs/0000074",
     "default" : null
   }, {
     "name" : "v_decontamsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000074",
+    "doc" : "https://w3id.org/mixs/0000074",
     "default" : null
   }, {
     "name" : "sorttech",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000075",
+    "doc" : "https://w3id.org/mixs/0000075",
     "default" : null
   }, {
     "name" : "v_sorttech",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000075",
+    "doc" : "https://w3id.org/mixs/0000075",
     "default" : null
   }, {
     "name" : "singlecelllysisappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000076",
+    "doc" : "https://w3id.org/mixs/0000076",
     "default" : null
   }, {
     "name" : "v_singlecelllysisappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000076",
+    "doc" : "https://w3id.org/mixs/0000076",
     "default" : null
   }, {
     "name" : "singlecelllysisprot",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000054",
+    "doc" : "https://w3id.org/mixs/0000054",
     "default" : null
   }, {
     "name" : "v_singlecelllysisprot",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000054",
+    "doc" : "https://w3id.org/mixs/0000054",
     "default" : null
   }, {
     "name" : "wgaampappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000055",
+    "doc" : "https://w3id.org/mixs/0000055",
     "default" : null
   }, {
     "name" : "v_wgaampappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000055",
+    "doc" : "https://w3id.org/mixs/0000055",
     "default" : null
   }, {
     "name" : "wgaampkit",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000006",
+    "doc" : "https://w3id.org/mixs/0000006",
     "default" : null
   }, {
     "name" : "v_wgaampkit",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000006",
+    "doc" : "https://w3id.org/mixs/0000006",
     "default" : null
   }, {
     "name" : "binparam",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000077",
+    "doc" : "https://w3id.org/mixs/0000077",
     "default" : null
   }, {
     "name" : "v_binparam",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000077",
+    "doc" : "https://w3id.org/mixs/0000077",
     "default" : null
   }, {
     "name" : "binsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000078",
+    "doc" : "https://w3id.org/mixs/0000078",
     "default" : null
   }, {
     "name" : "v_binsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000078",
+    "doc" : "https://w3id.org/mixs/0000078",
     "default" : null
   }, {
     "name" : "reassemblybin",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000079",
+    "doc" : "https://w3id.org/mixs/0000079",
     "default" : null
   }, {
     "name" : "v_reassemblybin",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000079",
+    "doc" : "https://w3id.org/mixs/0000079",
     "default" : null
   }, {
     "name" : "magcovsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000080",
+    "doc" : "https://w3id.org/mixs/0000080",
     "default" : null
   }, {
     "name" : "v_magcovsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000080",
+    "doc" : "https://w3id.org/mixs/0000080",
     "default" : null
   }, {
     "name" : "viridentsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000081",
+    "doc" : "https://w3id.org/mixs/0000081",
     "default" : null
   }, {
     "name" : "v_viridentsoftware",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000081",
+    "doc" : "https://w3id.org/mixs/0000081",
     "default" : null
   }, {
     "name" : "predgenometype",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000082",
+    "doc" : "https://w3id.org/mixs/0000082",
     "default" : null
   }, {
     "name" : "v_predgenometype",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000082",
+    "doc" : "https://w3id.org/mixs/0000082",
     "default" : null
   }, {
     "name" : "predgenomestruc",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000083",
+    "doc" : "https://w3id.org/mixs/0000083",
     "default" : null
   }, {
     "name" : "v_predgenomestruc",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000083",
+    "doc" : "https://w3id.org/mixs/0000083",
     "default" : null
   }, {
     "name" : "detectype",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000084",
+    "doc" : "https://w3id.org/mixs/0000084",
     "default" : null
   }, {
     "name" : "v_detectype",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000084",
+    "doc" : "https://w3id.org/mixs/0000084",
     "default" : null
   }, {
     "name" : "otuclassappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000085",
+    "doc" : "https://w3id.org/mixs/0000085",
     "default" : null
   }, {
     "name" : "v_otuclassappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000085",
+    "doc" : "https://w3id.org/mixs/0000085",
     "default" : null
   }, {
     "name" : "otuseqcompappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000086",
+    "doc" : "https://w3id.org/mixs/0000086",
     "default" : null
   }, {
     "name" : "v_otuseqcompappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000086",
+    "doc" : "https://w3id.org/mixs/0000086",
     "default" : null
   }, {
     "name" : "otudb",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000087",
+    "doc" : "https://w3id.org/mixs/0000087",
     "default" : null
   }, {
     "name" : "v_otudb",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000087",
+    "doc" : "https://w3id.org/mixs/0000087",
     "default" : null
   }, {
     "name" : "hostpredappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000088",
+    "doc" : "https://w3id.org/mixs/0000088",
     "default" : null
   }, {
     "name" : "v_hostpredappr",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000088",
+    "doc" : "https://w3id.org/mixs/0000088",
     "default" : null
   }, {
     "name" : "hostpredestacc",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000089",
+    "doc" : "https://w3id.org/mixs/0000089",
     "default" : null
   }, {
     "name" : "v_hostpredestacc",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000089",
+    "doc" : "https://w3id.org/mixs/0000089",
     "default" : null
   }, {
     "name" : "url",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000091",
+    "doc" : "https://w3id.org/mixs/0000091",
     "default" : null
   }, {
     "name" : "v_url",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000091",
+    "doc" : "https://w3id.org/mixs/0000091",
     "default" : null
   }, {
     "name" : "sop",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000090",
+    "doc" : "https://w3id.org/mixs/0000090",
     "default" : null
   }, {
     "name" : "v_sop",
     "type" : [ "null", "string" ],
-    "doc" : "https://w3id.org/gensc/terms/MIXS:0000090",
+    "doc" : "https://w3id.org/mixs/0000090",
     "default" : null
   }, {
     "name" : "pcrprimerforward",

--- a/occurrence-search/src/main/java/org/gbif/occurrence/search/es/OccurrenceSearchEsImpl.java
+++ b/occurrence-search/src/main/java/org/gbif/occurrence/search/es/OccurrenceSearchEsImpl.java
@@ -100,7 +100,7 @@ public class OccurrenceSearchEsImpl implements OccurrenceSearchService, Occurren
     this.esFieldMapper = esFieldMapper;
     this.esFulltextSuggestBuilder = EsFulltextSuggestBuilder.builder().occurrenceBaseEsFieldMapper(esFieldMapper).build();
     this.esSearchRequestBuilder = new EsSearchRequestBuilder(esFieldMapper, conceptClient, nameUsageMatchingService);
-    this.searchHitOccurrenceConverter = new SearchHitOccurrenceConverter(esFieldMapper, true, defaultChecklistKey);
+    this.searchHitOccurrenceConverter = new SearchHitOccurrenceConverter(esFieldMapper, true);
     this.esResponseParser = new EsResponseParser<>(esFieldMapper, searchHitOccurrenceConverter);
     this.defaultChecklistKey = defaultChecklistKey;
   }

--- a/occurrence-ws/src/main/java/org/gbif/occurrence/ws/resources/OccurrenceDownloadDescribeResource.java
+++ b/occurrence-ws/src/main/java/org/gbif/occurrence/ws/resources/OccurrenceDownloadDescribeResource.java
@@ -13,6 +13,7 @@
  */
 package org.gbif.occurrence.ws.resources;
 
+import org.gbif.api.model.Constants;
 import org.gbif.api.vocabulary.Extension;
 import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.dwc.terms.GbifTerm;
@@ -160,7 +161,7 @@ public class OccurrenceDownloadDescribeResource {
       .build();
 
     private final Table interpreted = Table.builder()
-      .fields(toFieldList(HIVE_QUERIES.selectInterpretedFields(false), true))
+      .fields(toFieldList(HIVE_QUERIES.selectInterpretedFields(false, Constants.NUB_DATASET_KEY.toString()), true))
       .build();
 
     private final List<String> verbatimExtensions =
@@ -288,7 +289,7 @@ public class OccurrenceDownloadDescribeResource {
 
   private static final Table SQL = Table.builder()
     .fields(ImmutableSet.<Field>builder()
-      .addAll(toTypedFieldList(HIVE_QUERIES.selectInterpretedFields(false), true))
+      .addAll(toTypedFieldList(HIVE_QUERIES.selectInterpretedFields(false, Constants.NUB_DATASET_KEY.toString()), true))
       .addAll(toTypedFieldList(HIVE_QUERIES.selectInternalSearchFields(false), true))
       .addAll(toTypedFieldList(HIVE_QUERIES.selectVerbatimFields(), false))
       .build()

--- a/occurrence-ws/src/test/java/org/gbif/occurrence/download/service/CallbackServiceTest.java
+++ b/occurrence-ws/src/test/java/org/gbif/occurrence/download/service/CallbackServiceTest.java
@@ -13,21 +13,6 @@
  */
 package org.gbif.occurrence.download.service;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
 import org.gbif.api.model.common.DOI;
 import org.gbif.api.model.occurrence.Download;
 import org.gbif.api.model.occurrence.Download.Status;
@@ -44,9 +29,27 @@ import org.gbif.api.vocabulary.Extension;
 import org.gbif.common.messaging.api.MessagePublisher;
 import org.gbif.occurrence.mail.EmailSender;
 import org.gbif.occurrence.mail.OccurrenceEmailManager;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 class CallbackServiceTest {
   private static final String DOWNLOAD_ID = "0000000-120518122602221";
@@ -78,9 +81,9 @@ class CallbackServiceTest {
             true,
             DownloadFormat.DWCA,
             DownloadType.OCCURRENCE,
-            "testDescription",
-            null,
-            Collections.singleton(Extension.AUDUBON));
+          "testDescription",
+          null,
+            Collections.singleton(Extension.AUDUBON), null);
     Download download = new Download();
     download.setRequest(downloadRequest);
     download.setKey(DOWNLOAD_ID);

--- a/occurrence-ws/src/test/java/org/gbif/occurrence/download/service/DownloadServiceImplTest.java
+++ b/occurrence-ws/src/test/java/org/gbif/occurrence/download/service/DownloadServiceImplTest.java
@@ -13,20 +13,6 @@
  */
 package org.gbif.occurrence.download.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.regex.Pattern;
 import org.gbif.api.model.common.paging.Pageable;
 import org.gbif.api.model.common.paging.PagingRequest;
 import org.gbif.api.model.common.paging.PagingResponse;
@@ -46,6 +32,14 @@ import org.gbif.api.vocabulary.Extension;
 import org.gbif.common.messaging.api.MessagePublisher;
 import org.gbif.occurrence.mail.EmailSender;
 import org.gbif.occurrence.mail.OccurrenceEmailManager;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Pattern;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,6 +47,14 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DownloadServiceImplTest {
@@ -95,9 +97,9 @@ class DownloadServiceImplTest {
             true,
             DownloadFormat.DWCA,
             DownloadType.OCCURRENCE,
-            "testDescription",
-            null,
-            Collections.singleton(Extension.AUDUBON));
+          "testDescription",
+          null,
+            Collections.singleton(Extension.AUDUBON), null);
     String id = requestService.create(dl, null);
 
     assertTrue(REGEX.matcher(id).matches());
@@ -113,9 +115,9 @@ class DownloadServiceImplTest {
             true,
             DownloadFormat.DWCA,
             DownloadType.OCCURRENCE,
-            "testDescription",
-            null,
-            Collections.singleton(Extension.AUDUBON));
+          "testDescription",
+          null,
+            Collections.singleton(Extension.AUDUBON), null);
 
     when(downloadLimitsService.exceedsDownloadComplexity(any())).thenReturn("test");
 
@@ -198,9 +200,9 @@ class DownloadServiceImplTest {
             true,
             DownloadFormat.DWCA,
             DownloadType.OCCURRENCE,
-            "testDescription",
-            null,
-            Collections.singleton(Extension.AUDUBON));
+          "testDescription",
+          null,
+            Collections.singleton(Extension.AUDUBON), null);
     Download download = new Download();
     download.setRequest(downloadRequest);
     download.setKey(downloadKey);

--- a/occurrence-ws/src/test/java/org/gbif/occurrence/ws/resources/OccurrenceDownloadResourceTest.java
+++ b/occurrence-ws/src/test/java/org/gbif/occurrence/ws/resources/OccurrenceDownloadResourceTest.java
@@ -13,15 +13,6 @@
  */
 package org.gbif.occurrence.ws.resources;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.security.Principal;
-import java.util.Collections;
 import org.gbif.api.model.common.GbifUser;
 import org.gbif.api.model.common.GbifUserPrincipal;
 import org.gbif.api.model.common.paging.PagingResponse;
@@ -32,11 +23,15 @@ import org.gbif.api.model.occurrence.PredicateDownloadRequest;
 import org.gbif.api.model.occurrence.SqlDownloadRequest;
 import org.gbif.api.model.occurrence.search.OccurrenceSearchParameter;
 import org.gbif.api.model.predicate.EqualsPredicate;
+import org.gbif.api.service.occurrence.DownloadRequestService;
+import org.gbif.api.service.registry.OccurrenceDownloadService;
 import org.gbif.api.vocabulary.Extension;
 import org.gbif.api.vocabulary.UserRole;
 import org.gbif.occurrence.download.service.CallbackService;
-import org.gbif.occurrence.download.service.OccurrenceDownloadRequestService;
-import org.gbif.registry.ws.client.OccurrenceDownloadClient;
+
+import java.security.Principal;
+import java.util.Collections;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -44,6 +39,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.server.ResponseStatusException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class OccurrenceDownloadResourceTest {
 
@@ -103,8 +105,8 @@ public class OccurrenceDownloadResourceTest {
   private void prepareMocks(String user, boolean failedCreation) {
     String archiveServerUrl = "http://test/";
     CallbackService callbackService = mock(CallbackService.class);
-    OccurrenceDownloadRequestService service = mock(OccurrenceDownloadRequestService.class);
-    OccurrenceDownloadClient downloadService = mock(OccurrenceDownloadClient.class);
+    DownloadRequestService service = mock(DownloadRequestService.class);
+    OccurrenceDownloadService downloadService = mock(OccurrenceDownloadService.class);
 
     GbifUser gbifUser = new GbifUser();
     gbifUser.setUserName(user);
@@ -125,29 +127,29 @@ public class OccurrenceDownloadResourceTest {
             true,
             DownloadFormat.DWCA,
             DownloadType.OCCURRENCE,
-            "testDescription",
-            null,
-            Collections.singleton(Extension.AUDUBON));
+          "testDescription",
+          null,
+            Collections.singleton(Extension.AUDUBON), null);
     sqlDl =
         new SqlDownloadRequest(
-            "SELECT gbifid FROM occurrence",
-            USER,
-            null,
-            true,
-            DownloadFormat.SQL_TSV_ZIP,
-            DownloadType.OCCURRENCE,
-            "testDescription",
-            null);
+           "SELECT gbifid FROM occurrence",
+           USER,
+           null,
+           true,
+          DownloadFormat.SQL_TSV_ZIP,
+          DownloadType.OCCURRENCE,
+          "testDescription",
+          null,null);
     badSqlDl =
         new SqlDownloadRequest(
-            "SELECT * FROM occurrence",
-            USER,
-            null,
-            true,
-            DownloadFormat.SQL_TSV_ZIP,
-            DownloadType.OCCURRENCE,
-            "testDescription",
-            null);
+           "SELECT * FROM occurrence",
+           USER,
+           null,
+           true,
+          DownloadFormat.SQL_TSV_ZIP,
+          DownloadType.OCCURRENCE,
+          "testDescription",
+          null,null);
 
     PagingResponse<Download> empty = new PagingResponse<>();
     empty.setResults(Collections.emptyList());

--- a/pom.xml
+++ b/pom.xml
@@ -214,9 +214,9 @@
     <!-- GBIF VERSIONS -->
     <hbase-utils.version>1.0.0</hbase-utils.version>
     <download-query-tools.version>2.0.3</download-query-tools.version>
-    <dwc-api.version>2.1.1</dwc-api.version>
+    <dwc-api.version>2.1.6</dwc-api.version>
     <dwca-io.version>3.0.0</dwca-io.version>
-    <gbif-api.version>2.1.14-SNAPSHOT</gbif-api.version>
+    <gbif-api.version>2.1.15</gbif-api.version>
     <gbif-common.version>0.59</gbif-common.version>
     <gbif-common-test.version>0.7</gbif-common-test.version>
     <gbif-common-service.version>0.19</gbif-common-service.version>
@@ -285,6 +285,8 @@
 
     <!-- Extensions -->
     <wagon-ssh.version>2.4</wagon-ssh.version>
+
+    <java.version>17</java.version>
   </properties>
 
   <!-- Profile created to manage multiple Hadoop version in different environments -->


### PR DESCRIPTION
With this PR,  users can specify a checklist to use in the downloads using a `checklistKey` parameter.
This provides the ability for the user to select the kingdom, phylum,....species and other taxonomic fields provided in the DWCA, CSV, AVRO etc from the chosen classification.


```bash
curl -X POST https://api.gbif-test.org/v1/occurrence/download/request \
     -u xxxx:xxxxx \
     -H "Content-Type: application/json" \
     -d '{
            "predicate": {
              "type": "and",
              "predicates": [
                {
                  "type": "in",
                  "key": "DATASET_KEY",
                  "values": [
                    "319a7c70-fcfe-48bf-af24-b1cd80d9cc7a"
                  ],
                  "matchCase": false
                }
              ]
            },
            "sendNotification": true,
            "format": "SIMPLE_CSV",
            "checklistKey": "7ddf754f-d193-4cc9-b351-99906754a03b",
            "type": "OCCURRENCE"
        }'
 ```       