### PR TITLE
Support for querying taxonomic issues 

### DIFF
--- a/event-ws/src/main/java/org/gbif/event/search/es/EventSearchEs.java
+++ b/event-ws/src/main/java/org/gbif/event/search/es/EventSearchEs.java
@@ -99,9 +99,9 @@ public class EventSearchEs implements SearchService<Event, OccurrenceSearchParam
     // create ES client
     this.esClient = esClient;
     this.nameUsageMatchingService = nameUsageMatchingService;
-    eventEsFieldMapper = EventEsField.buildFieldMapper(defaultChecklistKey);
-    occurrenceEsFieldMapper = OccurrenceEventEsField.buildFieldMapper(defaultChecklistKey);
-    this.esSearchRequestBuilder = new EsSearchRequestBuilder(eventEsFieldMapper, conceptClient, nameUsageMatchingService);
+    eventEsFieldMapper = EventEsField.buildFieldMapper();
+    occurrenceEsFieldMapper = OccurrenceEventEsField.buildFieldMapper();
+    this.esSearchRequestBuilder = new EsSearchRequestBuilder(eventEsFieldMapper, conceptClient, nameUsageMatchingService, defaultChecklistKey);
     searchHitEventConverter = new SearchHitEventConverter(eventEsFieldMapper, true);
     searchHitOccurrenceConverter = new SearchHitOccurrenceConverter(occurrenceEsFieldMapper, true);
     this.esResponseParser = new EsResponseParser<>(eventEsFieldMapper, searchHitEventConverter);

--- a/event-ws/src/main/java/org/gbif/event/ws/config/EventWsConfiguration.java
+++ b/event-ws/src/main/java/org/gbif/event/ws/config/EventWsConfiguration.java
@@ -77,7 +77,7 @@ public class EventWsConfiguration {
 
     @Bean
     public OccurrenceBaseEsFieldMapper esFieldMapper() {
-      return OccurrenceEsField.buildFieldMapper(defaultChecklistKey);
+      return OccurrenceEsField.buildFieldMapper();
     }
   }
 }

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/action/DownloadWorkflowModule.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/action/DownloadWorkflowModule.java
@@ -213,9 +213,9 @@ public class DownloadWorkflowModule  {
   }
 
 
-  public static OccurrenceBaseEsFieldMapper esFieldMapper(WorkflowConfiguration.SearchType searchType, String checklistKey) {
+  public static OccurrenceBaseEsFieldMapper esFieldMapper(WorkflowConfiguration.SearchType searchType) {
     return WorkflowConfiguration.SearchType.OCCURRENCE == searchType ?
-      OccurrenceEsField.buildFieldMapper(checklistKey) : EventEsField.buildFieldMapper(checklistKey);
+      OccurrenceEsField.buildFieldMapper() : EventEsField.buildFieldMapper();
   }
 
   /**
@@ -232,12 +232,10 @@ public class DownloadWorkflowModule  {
 
   private <T extends VerbatimOccurrence, S extends SearchHitConverter<T>> S searchHitConverter() {
     if (workflowConfiguration.getEsIndexType() == WorkflowConfiguration.SearchType.EVENT) {
-      return (S) new SearchHitEventConverter(esFieldMapper(workflowConfiguration.getEsIndexType(),
-        downloadJobConfiguration.getChecklistKey() != null ? downloadJobConfiguration.getChecklistKey() : workflowConfiguration.getDefaultChecklistKey()
+      return (S) new SearchHitEventConverter(esFieldMapper(workflowConfiguration.getEsIndexType()
       ), false);
     }
-    return (S) new SearchHitOccurrenceConverter(esFieldMapper(workflowConfiguration.getEsIndexType(),
-      downloadJobConfiguration.getChecklistKey() != null ? downloadJobConfiguration.getChecklistKey() : workflowConfiguration.getDefaultChecklistKey()
+    return (S) new SearchHitOccurrenceConverter(esFieldMapper(workflowConfiguration.getEsIndexType()
     ), false);
   }
 

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/conf/DownloadJobConfiguration.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/conf/DownloadJobConfiguration.java
@@ -140,8 +140,8 @@ public class DownloadJobConfiguration {
 
   public OccurrenceBaseEsFieldMapper esFieldMapper(Download download) {
     return DownloadType.OCCURRENCE == download.getRequest().getType()
-        ? OccurrenceEsField.buildFieldMapper(checklistKey)
-        : EventEsField.buildFieldMapper(checklistKey);
+        ? OccurrenceEsField.buildFieldMapper()
+        : EventEsField.buildFieldMapper();
   }
 
   /**

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/elastic/DownloadEsClient.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/elastic/DownloadEsClient.java
@@ -54,7 +54,9 @@ public class DownloadEsClient implements Closeable {
    */
   @SneakyThrows
   public long getRecordCount(Predicate predicate) {
-    CountResponse response = esClient.count(new CountRequest().indices(esIndex).query(EsPredicateUtil.searchQuery(predicate, esFieldMapper)),
+    CountResponse response = esClient.count(new CountRequest()
+        .indices(esIndex).query(EsPredicateUtil.searchQuery(predicate, esFieldMapper)
+      ),
       RequestOptions.DEFAULT);
     log.info("Download record count {}", response.getCount());
     return response.getCount();

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/file/DownloadMaster.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/file/DownloadMaster.java
@@ -115,7 +115,7 @@ public class DownloadMaster<T extends Occurrence> extends AbstractActor {
     this.esIndex = esIndex;
     this.aggregator = aggregator;
     this.occurrenceBaseEsFieldMapper = DownloadWorkflowModule.esFieldMapper(
-      workflowConfiguration.getEsIndexType(), jobConfiguration.getChecklistKey()
+      workflowConfiguration.getEsIndexType()
     );
     this.interpretedMapper = interpretedMapper;
     this.verbatimMapper = verbatimMapper;

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/file/OccurrenceMapReader.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/file/OccurrenceMapReader.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -163,6 +164,22 @@ public class OccurrenceMapReader {
         });
       }
       interpretedOccurrence.put(IucnTerm.iucnRedListCategory.simpleName(), getSimpleValue(occurrence.getIucnRedListCategory()));
+
+      // combine taxonomic issues for this classification, with non taxonomic issues
+      List<String> nonTaxonomicIssues = occurrence.getIssues().stream()
+        .filter(oi -> !OccurrenceIssue.TAXONOMIC_RULES.contains(oi)).map(OccurrenceIssue::name)
+        .toList();
+
+      List<String> taxonIssues = classification.getIssues() != null ? classification.getIssues() : List.of();
+      List<String> combinedIssues = Stream.concat(nonTaxonomicIssues.stream(), taxonIssues.stream())
+        .toList();
+
+      interpretedOccurrence.put(GbifTerm.issue.simpleName(), String.join(";", combinedIssues));
+
+    } else {
+
+      extractOccurrenceIssues(occurrence.getIssues())
+        .ifPresent(issues -> interpretedOccurrence.put(GbifTerm.issue.simpleName(), issues));
     }
 
     //location fields
@@ -191,8 +208,7 @@ public class OccurrenceMapReader {
     interpretedOccurrence.put(DwcTerm.higherGeography.simpleName(), getSimpleValueAndNormalizeDelimiters(occurrence.getHigherGeography()));
     interpretedOccurrence.put(DwcTerm.georeferencedBy.simpleName(), getSimpleValueAndNormalizeDelimiters(occurrence.getGeoreferencedBy()));
 
-    extractOccurrenceIssues(occurrence.getIssues())
-      .ifPresent(issues -> interpretedOccurrence.put(GbifTerm.issue.simpleName(), issues));
+
     extractMediaTypes(occurrence.getMedia())
       .ifPresent(mediaTypes -> interpretedOccurrence.put(GbifTerm.mediaType.simpleName(), mediaTypes));
     extractAgentIds(occurrence.getRecordedByIds())

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/HiveQueries.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/hive/HiveQueries.java
@@ -13,6 +13,8 @@
  */
 package org.gbif.occurrence.download.hive;
 
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.GbifTerm;
 import org.gbif.dwc.terms.Term;
 import org.gbif.occurrence.common.HiveColumnsUtils;
 import org.gbif.occurrence.common.TermUtils;
@@ -30,7 +32,18 @@ public class HiveQueries extends TsvQueries {
 
   @Override
   String toInterpretedHiveInitializer(Term term, String checklistKey) {
-    if (TermUtils.isTaxonomic(term)) {
+
+    if (term == GbifTerm.issue) {
+      return String.format(
+        "array_union(nontaxonomicissue, element_at(taxonomicissue, '%s')) as issue",
+        checklistKey
+      );
+    } else if (term == DwcTerm.taxonomicStatus) {
+        return String.format(
+          "element_at(taxonomicstatuses, '%s') as taxonomicstatus",
+          checklistKey
+        );
+    } else if (TermUtils.isTaxonomic(term)) {
       return toTaxonomicHiveInitializer(term, checklistKey);
     } else if (TermUtils.isInterpretedLocalDateSeconds(term)) {
       return secondsToLocalISO8601Initializer(term);

--- a/occurrence-download/src/main/java/org/gbif/occurrence/download/util/SqlValidation.java
+++ b/occurrence-download/src/main/java/org/gbif/occurrence/download/util/SqlValidation.java
@@ -241,7 +241,8 @@ public class SqlValidation {
       RelDataType parentEventGbifId = tdf.createArrayType(keyValuePair, -1);
 
       //  Map definition - needed for multiple classifications
-      RelDataType structMap = tdf.createMapType(varChar, varCharArray);
+      RelDataType structMap = tdf.createMapType(varChar, varChar);
+      RelDataType structMapOfArrays = tdf.createMapType(varChar, varCharArray);
       RelDataType structMapOfMap = tdf.createMapType(varChar, tdf.createMapType(varChar, varChar));
 
       OccurrenceHDFSTableDefinition.definition().stream().forEach(
@@ -263,6 +264,10 @@ public class SqlValidation {
 
             case HiveDataTypes.TYPE_MAP_STRUCT:
               builder.add(field.getColumnName(), structMap);
+              break;
+
+            case HiveDataTypes.TYPE_MAP_OF_ARRAY_STRUCT:
+              builder.add(field.getColumnName(), structMapOfArrays);
               break;
 
             case HiveDataTypes.TYPE_MAP_OF_MAP_STRUCT:

--- a/occurrence-download/src/test/java/org/gbif/occurrence/download/file/OccurrenceMapReaderTest.java
+++ b/occurrence-download/src/test/java/org/gbif/occurrence/download/file/OccurrenceMapReaderTest.java
@@ -86,7 +86,9 @@ public class OccurrenceMapReaderTest {
         org.gbif.api.v2.RankedName.builder().name("Tapiridae").rank("FAMILY").key("1").build(),
         org.gbif.api.v2.RankedName.builder().name("Tapirus").rank("GENUS").key("1").build(),
         org.gbif.api.v2.RankedName.builder().name("bairdii").rank("SPECIES").key("1").build()
-    )).build();
+      ))
+      .issues(List.of(OccurrenceIssue.TAXON_MATCH_FUZZY.name()))
+      .build();
 
     occurrence.setClassifications(
       Map.of(Constants.NUB_DATASET_KEY.toString(), classification));

--- a/occurrence-es-mapping/src/main/java/org/gbif/event/search/es/EventEsField.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/event/search/es/EventEsField.java
@@ -419,7 +419,7 @@ public enum EventEsField implements EsField {
   private static final Set<EsField> DATE_FIELDS =
     ImmutableSet.of(EVENT_DATE, DATE_IDENTIFIED, MODIFIED, LAST_INTERPRETED, LAST_CRAWLED, LAST_PARSED);
 
-  public static OccurrenceBaseEsFieldMapper buildFieldMapper(String defaultChecklistKey) {
+  public static OccurrenceBaseEsFieldMapper buildFieldMapper() {
     return OccurrenceBaseEsFieldMapper.builder()
       .fullTextField(FULL_TEXT)
       .geoShapeField(COORDINATE_SHAPE)
@@ -430,7 +430,6 @@ public enum EventEsField implements EsField {
       .searchToEsMapping(SEARCH_TO_ES_MAPPING)
       .dateFields(DATE_FIELDS)
       .fieldEnumClass(EventEsField.class)
-      .defaulChecklistKey(defaultChecklistKey)
       .build();
   }
 

--- a/occurrence-es-mapping/src/main/java/org/gbif/event/search/es/OccurrenceEventEsField.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/event/search/es/OccurrenceEventEsField.java
@@ -383,7 +383,7 @@ public enum OccurrenceEventEsField implements EsField {
 
   private static final Set<EsField> DATE_FIELDS = ImmutableSet.of(EVENT_DATE, DATE_IDENTIFIED, MODIFIED, LAST_INTERPRETED, LAST_CRAWLED,LAST_PARSED);
 
-  public static OccurrenceBaseEsFieldMapper buildFieldMapper(String defaultChecklistKey) {
+  public static OccurrenceBaseEsFieldMapper buildFieldMapper() {
       return OccurrenceBaseEsFieldMapper.builder()
         .fullTextField(FULL_TEXT)
         .geoShapeField(COORDINATE_SHAPE)
@@ -394,7 +394,6 @@ public enum OccurrenceEventEsField implements EsField {
         .searchToEsMapping(SEARCH_TO_ES_MAPPING)
         .dateFields(DATE_FIELDS)
         .fieldEnumClass(OccurrenceEventEsField.class)
-        .defaulChecklistKey(defaultChecklistKey)
         .build();
   }
 

--- a/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/OccurrenceBaseEsFieldMapper.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/OccurrenceBaseEsFieldMapper.java
@@ -16,6 +16,8 @@ package org.gbif.occurrence.search.es;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -59,8 +61,6 @@ public class OccurrenceBaseEsFieldMapper implements EsFieldMapper<OccurrenceSear
   // FIXME: this shouldn't be an Optional
   private final Optional<QueryBuilder> defaultFilter;
 
-  private final String defaulChecklistKey;
-
   @Builder
   public OccurrenceBaseEsFieldMapper(Map<OccurrenceSearchParameter,EsField> searchToEsMapping,
                                      Set<EsField> dateFields,
@@ -71,8 +71,7 @@ public class OccurrenceBaseEsFieldMapper implements EsFieldMapper<OccurrenceSear
                                      List<FieldSortBuilder> defaultSort,
                                      Optional<QueryBuilder> defaultFilter,
                                      Class<? extends Enum<? extends EsField>> fieldEnumClass,
-                                     @Nullable Map<OccurrenceSearchParameter,EsField> facetToEsMapping,
-                                     String defaulChecklistKey) {
+                                     @Nullable Map<OccurrenceSearchParameter,EsField> facetToEsMapping) {
     this.searchToEsMapping = searchToEsMapping;
     esToSearchMapping = searchToEsMapping.entrySet().stream().collect(Collectors.toMap(e -> e.getValue().getSearchFieldName(),
                                                                                             Map.Entry::getKey));
@@ -86,7 +85,6 @@ public class OccurrenceBaseEsFieldMapper implements EsFieldMapper<OccurrenceSear
     this.defaultSort = defaultSort;
     this.defaultFilter = defaultFilter;
     this.facetToEsMapping = facetToEsMapping == null? new HashMap<>(): facetToEsMapping;
-    this.defaulChecklistKey = defaulChecklistKey;
   }
 
   public OccurrenceSearchParameter getSearchParameter(String searchFieldName) {
@@ -209,7 +207,7 @@ public class OccurrenceBaseEsFieldMapper implements EsFieldMapper<OccurrenceSear
    * @return the field name for the checklist field
    */
   @Override
-  public String getChecklistField(String checklistKey, OccurrenceSearchParameter searchParameter) {
+  public String getChecklistField(@NotNull String checklistKey, OccurrenceSearchParameter searchParameter) {
 
     EsField esField = getEsField(searchParameter);
     if (esField == null) {
@@ -226,8 +224,7 @@ public class OccurrenceBaseEsFieldMapper implements EsFieldMapper<OccurrenceSear
     }
 
     if (baseEsField instanceof ChecklistEsField) {
-      return ((ChecklistEsField) baseEsField)
-          .getSearchFieldName(checklistKey != null ? checklistKey : defaulChecklistKey);
+      return ((ChecklistEsField) baseEsField).getSearchFieldName(checklistKey);
     }
 
     return esField.getSearchFieldName();

--- a/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/OccurrenceEsField.java
+++ b/occurrence-es-mapping/src/main/java/org/gbif/occurrence/search/es/OccurrenceEsField.java
@@ -427,7 +427,7 @@ public enum OccurrenceEsField implements EsField {
       .build();
   private static final Set<EsField> DATE_FIELDS = ImmutableSet.of(EVENT_DATE, EVENT_DATE_GTE, DATE_IDENTIFIED, MODIFIED, LAST_INTERPRETED, LAST_CRAWLED, LAST_PARSED);
 
-  public static OccurrenceBaseEsFieldMapper buildFieldMapper(String defaultChecklistKey) {
+  public static OccurrenceBaseEsFieldMapper buildFieldMapper() {
       return OccurrenceBaseEsFieldMapper.builder()
         .fullTextField(FULL_TEXT)
         .geoShapeField(COORDINATE_SHAPE)
@@ -439,7 +439,6 @@ public enum OccurrenceEsField implements EsField {
         .dateFields(DATE_FIELDS)
         .facetToEsMapping(FACET_TO_ES_MAPPING)
         .fieldEnumClass(OccurrenceEsField.class)
-        .defaulChecklistKey(defaultChecklistKey)
         .build();
   }
 

--- a/occurrence-es-mapping/src/test/java/org/gbif/predicate/query/EsQueryVisitorTest.java
+++ b/occurrence-es-mapping/src/test/java/org/gbif/predicate/query/EsQueryVisitorTest.java
@@ -57,7 +57,7 @@ public class EsQueryVisitorTest {
   private static final OccurrenceSearchParameter PARAM2 =
       OccurrenceSearchParameter.INSTITUTION_CODE;
 
-  private final EsFieldMapper<OccurrenceSearchParameter> occurrenceEsFieldMapper = OccurrenceEsField.buildFieldMapper("defaultChecklistKey");
+  private final EsFieldMapper<OccurrenceSearchParameter> occurrenceEsFieldMapper = OccurrenceEsField.buildFieldMapper();
   private final EsQueryVisitor<OccurrenceSearchParameter> visitor =
       new EsQueryVisitor<>(occurrenceEsFieldMapper);
 
@@ -1586,7 +1586,7 @@ public class EsQueryVisitorTest {
 
   @Test
   public void testVocabularyEqualsPredicate() {
-    OccurrenceBaseEsFieldMapper esFieldMapper = OccurrenceEsField.buildFieldMapper("defaultChecklistKey");
+    OccurrenceBaseEsFieldMapper esFieldMapper = OccurrenceEsField.buildFieldMapper();
     Arrays.stream(OccurrenceSearchParameter.values())
         .filter(esFieldMapper::isVocabulary)
         .forEach(

--- a/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/HiveDataTypes.java
+++ b/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/HiveDataTypes.java
@@ -53,7 +53,8 @@ public final class HiveDataTypes {
       "STRUCT<concept: STRING,lineage: ARRAY<STRING>>";
   public static final String TYPE_VOCABULARY_ARRAY_STRUCT =
       "STRUCT<concepts: ARRAY<STRING>,lineage: ARRAY<STRING>>";
-  public static final String TYPE_MAP_STRUCT = "MAP<STRING, ARRAY<STRING>>";
+  public static final String TYPE_MAP_STRUCT = "MAP<STRING, STRING>";
+  public static final String TYPE_MAP_OF_ARRAY_STRUCT = "MAP<STRING, ARRAY<STRING>>";
   public static final String TYPE_MAP_OF_MAP_STRUCT = "MAP<STRING, MAP<STRING, STRING>>";
   public static final String TYPE_MAP_OF_MAP_ARRAY_STRUCT = "MAP<STRING, MAP<STRING, ARRAY<STRING>>>";
   public static final String TYPE_ARRAY_PARENT_STRUCT =
@@ -223,7 +224,13 @@ public final class HiveDataTypes {
         return TYPE_VOCABULARY_STRUCT;
       }
     } else if (term.equals(GbifInternalTerm.classifications)) {
+      return TYPE_MAP_OF_ARRAY_STRUCT;
+    } else if (term.equals(GbifInternalTerm.taxonomicStatuses)) {
       return TYPE_MAP_STRUCT;
+    } else if (term.equals(GbifTerm.nonTaxonomicIssue)) {
+      return TYPE_ARRAY_STRING;
+    } else if (term.equals(GbifTerm.taxonomicIssue)) {
+      return TYPE_MAP_OF_ARRAY_STRUCT;
     } else if (term.equals(GbifInternalTerm.classificationDetails)) {
       return TYPE_MAP_OF_MAP_STRUCT;
     } else {

--- a/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/OccurrenceAvroHdfsTableDefinition.java
+++ b/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/OccurrenceAvroHdfsTableDefinition.java
@@ -59,11 +59,14 @@ public class OccurrenceAvroHdfsTableDefinition {
       case HiveDataTypes.TYPE_ARRAY_STRING:
         builder.name(initializableField.getColumnName()).type().nullable().array().items().nullable().stringType().noDefault();
         break;
-      case HiveDataTypes.TYPE_MAP_STRUCT:
+      case HiveDataTypes.TYPE_MAP_OF_ARRAY_STRUCT:
         builder.name(initializableField.getColumnName()).type().nullable().map().values().array().items().stringType().noDefault();
         break;
       case HiveDataTypes.TYPE_MAP_OF_MAP_STRUCT:
         builder.name(initializableField.getColumnName()).type().nullable().map().values().map().values().stringType().noDefault();
+        break;
+      case HiveDataTypes.TYPE_MAP_STRUCT:
+        builder.name(initializableField.getColumnName()).type().nullable().map().values().stringType().noDefault();
         break;
       case HiveDataTypes.TYPE_VOCABULARY_STRUCT:
         builder.name(initializableField.getColumnName()).type().nullable().record(getTypeRecordName(initializableField))

--- a/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/OccurrenceHDFSTableDefinition.java
+++ b/occurrence-hdfs-table/src/main/java/org/gbif/occurrence/download/hive/OccurrenceHDFSTableDefinition.java
@@ -100,6 +100,7 @@ public class OccurrenceHDFSTableDefinition {
                                       .put(DwcTerm.eventType, columnFor(DwcTerm.eventType))
                                       .put(IucnTerm.iucnRedListCategory, columnFor(IucnTerm.iucnRedListCategory))
                                       .put(GbifInternalTerm.classifications, columnFor(GbifInternalTerm.classifications))
+                                      .put(GbifInternalTerm.taxonomicStatuses, columnFor(GbifInternalTerm.taxonomicStatuses))
                                       .put(GbifInternalTerm.classificationDetails, columnFor(GbifInternalTerm.classificationDetails))
                                       .put(GbifTerm.checklistKey, columnFor(GbifTerm.checklistKey))
                                       .build();

--- a/occurrence-heatmaps/src/main/java/org/gbif/occurrence/search/heatmap/es/EsHeatmapRequestBuilder.java
+++ b/occurrence-heatmaps/src/main/java/org/gbif/occurrence/search/heatmap/es/EsHeatmapRequestBuilder.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.aggregations.metrics.GeoCentroidAggregationBuild
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.springframework.beans.factory.annotation.Value;
 
 class EsHeatmapRequestBuilder {
 
@@ -46,10 +45,11 @@ class EsHeatmapRequestBuilder {
 
   EsHeatmapRequestBuilder(OccurrenceBaseEsFieldMapper occurrenceBaseEsFieldMapper,
                           ConceptClient conceptClient,
-                          NameUsageMatchingService nameUsageMatchingService) {
+                          NameUsageMatchingService nameUsageMatchingService,
+                          String defaultChecklistKey) {
     this.occurrenceBaseEsFieldMapper = occurrenceBaseEsFieldMapper;
     this.esSearchRequestBuilder = new EsSearchRequestBuilder(occurrenceBaseEsFieldMapper,
-      conceptClient, nameUsageMatchingService);
+      conceptClient, nameUsageMatchingService, defaultChecklistKey);
   }
 
   @VisibleForTesting

--- a/occurrence-heatmaps/src/main/java/org/gbif/occurrence/search/heatmap/es/OccurrenceHeatmapsEsService.java
+++ b/occurrence-heatmaps/src/main/java/org/gbif/occurrence/search/heatmap/es/OccurrenceHeatmapsEsService.java
@@ -59,11 +59,12 @@ public class OccurrenceHeatmapsEsService
       String esIndex,
       OccurrenceBaseEsFieldMapper occurrenceBaseEsFieldMapper,
       ConceptClient conceptClient,
-      NameUsageMatchingService nameUsageMatchingService) {
+      NameUsageMatchingService nameUsageMatchingService,
+      @Value("${defaultChecklistKey}") String defaultChecklistKey) {
     this.esIndex = esIndex;
     this.esClient = esClient;
     this.esHeatmapRequestBuilder = new EsHeatmapRequestBuilder(occurrenceBaseEsFieldMapper,
-      conceptClient, nameUsageMatchingService);
+      conceptClient, nameUsageMatchingService, defaultChecklistKey);
   }
 
   @Override

--- a/occurrence-heatmaps/src/test/java/org/gbif/occurrence/search/heatmap/es/EsHeatmapRequestBuilderTest.java
+++ b/occurrence-heatmaps/src/test/java/org/gbif/occurrence/search/heatmap/es/EsHeatmapRequestBuilderTest.java
@@ -42,8 +42,8 @@ public class EsHeatmapRequestBuilderTest {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final String INDEX = "index";
   private final EsHeatmapRequestBuilder esHeatmapRequestBuilder =
-      new EsHeatmapRequestBuilder(OccurrenceEsField.buildFieldMapper("defaultChecklistKey"),
-        null, null);
+      new EsHeatmapRequestBuilder(OccurrenceEsField.buildFieldMapper(),
+        null, null, "defaultChecklistKey");
 
   @Test
   public void heatmapRequestTest() throws IOException {

--- a/occurrence-integration-tests/src/test/java/org/gbif/occurrence/ws/it/OccurrenceWsItConfiguration.java
+++ b/occurrence-integration-tests/src/test/java/org/gbif/occurrence/ws/it/OccurrenceWsItConfiguration.java
@@ -156,7 +156,7 @@ public class OccurrenceWsItConfiguration {
 
   @Bean
   public OccurrenceBaseEsFieldMapper esFieldMapper() {
-    return OccurrenceEsField.buildFieldMapper("defaultChecklistKey");
+    return OccurrenceEsField.buildFieldMapper();
   }
 
   /** Mock name matching service. */

--- a/occurrence-search/src/main/java/org/gbif/occurrence/search/es/OccurrenceSearchEsImpl.java
+++ b/occurrence-search/src/main/java/org/gbif/occurrence/search/es/OccurrenceSearchEsImpl.java
@@ -100,7 +100,7 @@ public class OccurrenceSearchEsImpl implements OccurrenceSearchService, Occurren
     this.nameUsageMatchingService = nameUsageMatchingService;
     this.esFieldMapper = esFieldMapper;
     this.esFulltextSuggestBuilder = EsFulltextSuggestBuilder.builder().occurrenceBaseEsFieldMapper(esFieldMapper).build();
-    this.esSearchRequestBuilder = new EsSearchRequestBuilder(esFieldMapper, conceptClient, nameUsageMatchingService);
+    this.esSearchRequestBuilder = new EsSearchRequestBuilder(esFieldMapper, conceptClient, nameUsageMatchingService, defaultChecklistKey);
     this.searchHitOccurrenceConverter = new SearchHitOccurrenceConverter(esFieldMapper, true);
     this.esResponseParser = new EsResponseParser<>(esFieldMapper, searchHitOccurrenceConverter);
     this.defaultChecklistKey = defaultChecklistKey;

--- a/occurrence-search/src/test/java/org/gbif/occurrence/search/es/EventEsSearchRequestBuilderTest.java
+++ b/occurrence-search/src/test/java/org/gbif/occurrence/search/es/EventEsSearchRequestBuilderTest.java
@@ -48,7 +48,7 @@ public class EventEsSearchRequestBuilderTest {
 
   private final EsSearchRequestBuilder esSearchRequestBuilder =
       new EsSearchRequestBuilder(
-          EventEsField.buildFieldMapper(DEFAULT_CHECKLIST_KEY), new ConceptClientMock(), null);
+          EventEsField.buildFieldMapper(), new ConceptClientMock(), null, DEFAULT_CHECKLIST_KEY);
 
   @Test
   public void humboldtTaxonomyTest() throws Exception {
@@ -335,10 +335,10 @@ public class EventEsSearchRequestBuilderTest {
   public void humboldtTaxonomyPredicateTest() throws Exception {
     Predicate p1 =
         new EqualsPredicate<>(
-            OccurrenceSearchParameter.HUMBOLDT_TARGET_TAXONOMIC_SCOPE_USAGE_KEY, "uk", false);
+            OccurrenceSearchParameter.HUMBOLDT_TARGET_TAXONOMIC_SCOPE_USAGE_KEY, "uk", false, DEFAULT_CHECKLIST_KEY);
     Predicate p2 =
         new EqualsPredicate<>(
-            OccurrenceSearchParameter.HUMBOLDT_TARGET_TAXONOMIC_SCOPE_TAXON_KEY, "tk", false);
+            OccurrenceSearchParameter.HUMBOLDT_TARGET_TAXONOMIC_SCOPE_TAXON_KEY, "tk", false, DEFAULT_CHECKLIST_KEY);
     OccurrencePredicateSearchRequest searchRequest = new OccurrencePredicateSearchRequest();
     searchRequest.setPredicate(new ConjunctionPredicate(List.of(p1, p2)));
 

--- a/occurrence-search/src/test/java/org/gbif/occurrence/search/es/OccurrenceEsSearchRequestBuilderTest.java
+++ b/occurrence-search/src/test/java/org/gbif/occurrence/search/es/OccurrenceEsSearchRequestBuilderTest.java
@@ -46,7 +46,8 @@ public class OccurrenceEsSearchRequestBuilderTest {
   private static final String INDEX = "index";
 
   private final EsSearchRequestBuilder esSearchRequestBuilder =
-      new EsSearchRequestBuilder(OccurrenceEsField.buildFieldMapper("defaultChecklistKey"), new ConceptClientMock(), null);
+      new EsSearchRequestBuilder(OccurrenceEsField.buildFieldMapper(), new ConceptClientMock(), null,
+        "defaultChecklistKey");
 
   @Test
   public void termQueryTest() throws IOException {
@@ -743,7 +744,7 @@ public class OccurrenceEsSearchRequestBuilderTest {
     JsonNode jsonQuery = MAPPER.readTree(request.source().toString());
     LOG.debug("Query: {}", jsonQuery);
 
-    OccurrenceBaseEsFieldMapper esFieldMapper = OccurrenceEsField.buildFieldMapper("defaultChecklistKey");
+    OccurrenceBaseEsFieldMapper esFieldMapper = OccurrenceEsField.buildFieldMapper();
     EsField esField = esFieldMapper.getEsField(param);
 
     assertEquals(

--- a/occurrence-ws/src/main/java/org/gbif/occurrence/ws/config/OccurrenceWsConfiguration.java
+++ b/occurrence-ws/src/main/java/org/gbif/occurrence/ws/config/OccurrenceWsConfiguration.java
@@ -57,12 +57,9 @@ public class OccurrenceWsConfiguration {
   @Configuration
   public static class OccurrenceSearchConfigurationWs extends OccurrenceSearchConfiguration {
 
-    @Value("${defaultChecklistKey}")
-    protected String defaultChecklistKey;
-
     @Bean
     public OccurrenceBaseEsFieldMapper esFieldMapper() {
-      return OccurrenceEsField.buildFieldMapper(defaultChecklistKey);
+      return OccurrenceEsField.buildFieldMapper();
     }
   }
 

--- a/occurrence-ws/src/main/java/org/gbif/occurrence/ws/resources/OccurrenceSearchResource.java
+++ b/occurrence-ws/src/main/java/org/gbif/occurrence/ws/resources/OccurrenceSearchResource.java
@@ -132,8 +132,8 @@ public class OccurrenceSearchResource {
     this.searchService = searchService;
     this.searchTermService = searchTermService;
     this.esSearchRequestBuilder =
-        new EsSearchRequestBuilder(OccurrenceEsField.buildFieldMapper(defaultChecklistKey),
-          conceptClient, nameUsageMatchingService);
+        new EsSearchRequestBuilder(OccurrenceEsField.buildFieldMapper(),
+          conceptClient, nameUsageMatchingService, defaultChecklistKey);
   }
 
   /**


### PR DESCRIPTION
* Fixes for isNull, isNotNull predicates for multi taxonomy queries
* Support for querying taxonomic issues for the specified `checklistKey`
* Fix for the issue described [here](https://github.com/gbif/gbif-web/issues/1241#issuecomment-3516290940)
* Combining non taxonomic and taxonomic issues in the downloads to supplied combined issues in a single field (selecting the right taxonomy)
