### PR TITLE
fix(downloads): AirflowClient's HTTP calls had no timeouts, a hung Ai…

### DIFF
--- a/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/pojo/AirflowConfiguration.java
+++ b/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/pojo/AirflowConfiguration.java
@@ -56,6 +56,12 @@ public class AirflowConfiguration {
 
   public long apiCheckDelaySec = 3L;
 
+  /** Connect/connection-request timeout for calls to the Airflow REST API. */
+  public int connectTimeoutSec = 10;
+
+  /** Socket (read) timeout for calls to the Airflow REST API. */
+  public int socketTimeoutSec = 30;
+
   private DownloadPodConfiguration podConfiguration;
 
   @JsonIgnore

--- a/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherService.java
+++ b/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherService.java
@@ -45,6 +45,8 @@ import static org.gbif.api.model.occurrence.Download.Status.SUCCEEDED;
 @Slf4j
 public abstract class AirflowDownloadLauncherService implements DownloadLauncher {
 
+  private static final int FAILED_STATUS_UPDATE_MAX_ATTEMPTS = 3;
+
   private static final Retry AIRFLOW_RETRY =
       Retry.of(
           "airflowApiCall",
@@ -313,12 +315,7 @@ public abstract class AirflowDownloadLauncherService implements DownloadLauncher
                 download.getKey(),
                 ex);
             try {
-              Download currentDownload = downloadClient.get(download.getKey());
-              if (currentDownload != null
-                  && !FINISH_STATUSES.contains(currentDownload.getStatus())) {
-                currentDownload.setStatus(Status.FAILED);
-                downloadClient.update(currentDownload);
-              }
+              markDownloadAsFailed(download.getKey());
             } catch (Exception updateEx) {
               log.error(
                   "Failed to update download {} status to FAILED", download.getKey(), updateEx);
@@ -327,6 +324,25 @@ public abstract class AirflowDownloadLauncherService implements DownloadLauncher
             lockerService.unlock(download.getKey());
           }
         });
+  }
+
+  void markDownloadAsFailed(String downloadKey) throws Exception {
+    for (int attempt = 1; attempt <= FAILED_STATUS_UPDATE_MAX_ATTEMPTS; attempt++) {
+      Download currentDownload = downloadClient.get(downloadKey);
+      if (currentDownload == null || FINISH_STATUSES.contains(currentDownload.getStatus())) {
+        return;
+      }
+
+      currentDownload.setStatus(Status.FAILED);
+      try {
+        downloadClient.update(currentDownload);
+        return;
+      } catch (Exception ex) {
+        if (attempt == FAILED_STATUS_UPDATE_MAX_ATTEMPTS) {
+          throw ex;
+        }
+      }
+    }
   }
 
   protected abstract AirflowClient getAirflowClient();

--- a/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherService.java
+++ b/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherService.java
@@ -306,7 +306,19 @@ public abstract class AirflowDownloadLauncherService implements DownloadLauncher
                 download.getKey(),
                 status.orElse(null));
           } catch (Exception ex) {
-            log.error(ex.getMessage(), ex);
+            // Airflow API calls are already retried extensively (see AIRFLOW_RETRY); reaching
+            // here means Airflow is unreachable/unresponsive for an extended period.
+            log.error(
+                "Giving up on status checks for download {}, marking as FAILED",
+                download.getKey(),
+                ex);
+            try {
+              download.setStatus(Status.FAILED);
+              downloadClient.update(download);
+            } catch (Exception updateEx) {
+              log.error(
+                  "Failed to update download {} status to FAILED", download.getKey(), updateEx);
+            }
           } finally {
             lockerService.unlock(download.getKey());
           }
@@ -321,6 +333,8 @@ public abstract class AirflowDownloadLauncherService implements DownloadLauncher
         .airflowUser(airflowConfiguration.airflowUser)
         .airflowPass(airflowConfiguration.airflowPass)
         .airflowDagName(dagName)
+        .connectTimeoutSec(airflowConfiguration.connectTimeoutSec)
+        .socketTimeoutSec(airflowConfiguration.socketTimeoutSec)
         .build();
   }
 }

--- a/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherService.java
+++ b/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherService.java
@@ -313,8 +313,12 @@ public abstract class AirflowDownloadLauncherService implements DownloadLauncher
                 download.getKey(),
                 ex);
             try {
-              download.setStatus(Status.FAILED);
-              downloadClient.update(download);
+              Download currentDownload = downloadClient.get(download.getKey());
+              if (currentDownload != null
+                  && !FINISH_STATUSES.contains(currentDownload.getStatus())) {
+                currentDownload.setStatus(Status.FAILED);
+                downloadClient.update(currentDownload);
+              }
             } catch (Exception updateEx) {
               log.error(
                   "Failed to update download {} status to FAILED", download.getKey(), updateEx);

--- a/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/services/launcher/airflow/AirflowClient.java
+++ b/occurrence-download-launcher/src/main/java/org/gbif/occurrence/downloads/launcher/services/launcher/airflow/AirflowClient.java
@@ -15,9 +15,11 @@ package org.gbif.occurrence.downloads.launcher.services.launcher.airflow;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPatch;
@@ -52,6 +54,10 @@ public class AirflowClient {
 
   public final String airflowDagName;
 
+  @Builder.Default public final int connectTimeoutSec = 10;
+
+  @Builder.Default public final int socketTimeoutSec = 30;
+
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private String getUri() {
@@ -62,10 +68,25 @@ public class AirflowClient {
     return String.join("/", getUri(), paths);
   }
 
+  /**
+   * A hung Airflow webserver must not block the calling thread forever: without these timeouts a
+   * stalled connection leaves the status-polling loop parked, which in turn leaves the RabbitMQ
+   * consumer thread parked and the message permanently unacknowledged.
+   */
+  private CloseableHttpClient buildClient() {
+    RequestConfig requestConfig =
+        RequestConfig.custom()
+            .setConnectTimeout((int) TimeUnit.SECONDS.toMillis(connectTimeoutSec))
+            .setConnectionRequestTimeout((int) TimeUnit.SECONDS.toMillis(connectTimeoutSec))
+            .setSocketTimeout((int) TimeUnit.SECONDS.toMillis(socketTimeoutSec))
+            .build();
+    return HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
+  }
+
   @SneakyThrows
   public JsonNode createRun(AirflowBody body) {
 
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = buildClient()) {
       JsonNode dagRun = getRun(body.getDagRunId());
       if (dagRun.has("dag_run_id")
           && dagRun.get("dag_run_id").asText().equals(body.getDagRunId())) {
@@ -83,7 +104,7 @@ public class AirflowClient {
 
   @SneakyThrows
   public JsonNode clearRun(String dagRunId) {
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = buildClient()) {
       HttpPost post = new HttpPost(getUri(dagRunId) + "/clear");
       post.setEntity(new StringEntity("{\"dry_run\": false}"));
       post.setHeaders(getHeaders());
@@ -93,7 +114,7 @@ public class AirflowClient {
 
   @SneakyThrows
   public JsonNode deleteRun(String dagRunId) {
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = buildClient()) {
       HttpDelete delete = new HttpDelete(getUri(dagRunId));
       delete.setHeaders(getHeaders());
       return MAPPER.readTree(client.execute(delete).getEntity().getContent());
@@ -102,7 +123,7 @@ public class AirflowClient {
 
   @SneakyThrows
   public JsonNode failRun(String dagRunId) {
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = buildClient()) {
       HttpPatch patch = new HttpPatch(getUri(dagRunId));
       patch.setEntity(new StringEntity("{\"state\": \"failed\"}"));
       patch.setHeaders(getHeaders());
@@ -112,7 +133,7 @@ public class AirflowClient {
 
   @SneakyThrows
   public JsonNode setCancelledNote(String dagRunId) {
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = buildClient()) {
       HttpPatch patch = new HttpPatch(getUri(dagRunId) + "/setNote");
       patch.setEntity(new StringEntity("{\"note\": \"CANCELLED\"}"));
       patch.setHeaders(getHeaders());
@@ -122,7 +143,7 @@ public class AirflowClient {
 
   @SneakyThrows
   public JsonNode getRun(String dagRunId) {
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = buildClient()) {
       HttpGet get = new HttpGet(getUri(dagRunId));
       get.setHeaders(getHeaders());
       return MAPPER.readTree(client.execute(get).getEntity().getContent());

--- a/occurrence-download-launcher/src/test/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherServiceTest.java
+++ b/occurrence-download-launcher/src/test/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherServiceTest.java
@@ -57,12 +57,17 @@ class AirflowDownloadLauncherServiceTest {
   @Test
   void markDownloadAsFailedRetriesWithFreshReadAfterConflict() throws Exception {
     Download staleDownload = new Download();
+    staleDownload.setKey("stale");
     staleDownload.setStatus(Status.RUNNING);
     Download refreshedDownload = new Download();
+    refreshedDownload.setKey("refreshed");
     refreshedDownload.setStatus(Status.RUNNING);
 
     when(downloadClient.get(DOWNLOAD_KEY)).thenReturn(staleDownload, refreshedDownload);
-    doThrow(new RuntimeException("conflict")).doNothing().when(downloadClient).update(any());
+    doThrow(new RuntimeException("conflict"))
+        .doReturn(refreshedDownload)
+        .when(downloadClient)
+        .update(any());
 
     launcherService.markDownloadAsFailed(DOWNLOAD_KEY);
 

--- a/occurrence-download-launcher/src/test/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherServiceTest.java
+++ b/occurrence-download-launcher/src/test/java/org/gbif/occurrence/downloads/launcher/services/launcher/AirflowDownloadLauncherServiceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gbif.occurrence.downloads.launcher.services.launcher;
+
+import org.gbif.api.model.occurrence.Download;
+import org.gbif.api.model.occurrence.Download.Status;
+import org.gbif.occurrence.downloads.launcher.pojo.AirflowConfiguration;
+import org.gbif.occurrence.downloads.launcher.pojo.SparkStaticConfiguration;
+import org.gbif.occurrence.downloads.launcher.services.LockerService;
+import org.gbif.occurrence.downloads.launcher.services.launcher.airflow.AirflowClient;
+import org.gbif.registry.ws.client.BaseDownloadClient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
+
+class AirflowDownloadLauncherServiceTest {
+
+  private static final String DOWNLOAD_KEY = "000001";
+
+  private BaseDownloadClient downloadClient;
+  private AirflowDownloadLauncherService launcherService;
+
+  @BeforeEach
+  void setUp() {
+    downloadClient = mock(BaseDownloadClient.class);
+    launcherService =
+        new AirflowDownloadLauncherService(
+            new SparkStaticConfiguration(),
+            new AirflowConfiguration(),
+            downloadClient,
+            mock(LockerService.class)) {
+          @Override
+          protected boolean isSmallLauncher() {
+            return false;
+          }
+
+          @Override
+          protected AirflowClient getAirflowClient() {
+            return mock(AirflowClient.class);
+          }
+        };
+  }
+
+  @Test
+  void markDownloadAsFailedRetriesWithFreshReadAfterConflict() throws Exception {
+    Download staleDownload = new Download();
+    staleDownload.setStatus(Status.RUNNING);
+    Download refreshedDownload = new Download();
+    refreshedDownload.setStatus(Status.RUNNING);
+
+    when(downloadClient.get(DOWNLOAD_KEY)).thenReturn(staleDownload, refreshedDownload);
+    doThrow(new RuntimeException("conflict")).doNothing().when(downloadClient).update(any());
+
+    launcherService.markDownloadAsFailed(DOWNLOAD_KEY);
+
+    verify(downloadClient, times(2)).get(DOWNLOAD_KEY);
+    verify(downloadClient, times(2)).update(any(Download.class));
+    verify(downloadClient).update(staleDownload);
+    verify(downloadClient).update(refreshedDownload);
+  }
+
+  @Test
+  void markDownloadAsFailedStopsWhenConflictLosesToTerminalStatus() throws Exception {
+    Download staleDownload = new Download();
+    staleDownload.setStatus(Status.RUNNING);
+    Download succeededDownload = new Download();
+    succeededDownload.setStatus(Status.SUCCEEDED);
+
+    when(downloadClient.get(DOWNLOAD_KEY)).thenReturn(staleDownload, succeededDownload);
+    doThrow(new RuntimeException("conflict")).when(downloadClient).update(staleDownload);
+
+    launcherService.markDownloadAsFailed(DOWNLOAD_KEY);
+
+    verify(downloadClient, times(2)).get(DOWNLOAD_KEY);
+    verify(downloadClient, times(1)).update(any(Download.class));
+    verify(downloadClient).update(staleDownload);
+    verify(downloadClient, never()).update(succeededDownload);
+  }
+}


### PR DESCRIPTION
Airflow webserver could block the status-polling thread forever, leaving the RabbitMQ consumer thread parked and its message unacknowledged (restarting the launcher only masked this by killing the hung thread). Also mark a download FAILED, instead of leaving it stuck, when status polling exhausts retries.

https://github.com/gbif/occurrence/issues/575